### PR TITLE
更新开元阅读仓库描述与官方站点

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,12 @@
   </p>
 
   <p>
+    <a href="https://open.xxread.top/"><strong>Open Reading website</strong></a> ·
+    <a href="https://community.xxread.top/">Xiaoyuan Reader Community</a> ·
+    <a href="https://xxread.top/">Xiaoyuan Reader (iOS only)</a>
+  </p>
+
+  <p>
     <a href="https://flutter.dev/"><img src="https://img.shields.io/badge/Flutter-3.x-02569B?logo=flutter&logoColor=white" alt="Flutter"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-2ea44f" alt="MIT License"></a>
     <img src="https://img.shields.io/badge/Reader_Engine-Flutter_Native-0ea5e9" alt="Flutter Native Reader Engine">
@@ -24,6 +30,14 @@ Open Reading is an open-source ebook reader built with Flutter. It keeps books,
 progress, bookmarks, and notes on the user's device by default while providing
 careful typography, TTS, annotations, reading statistics, optional AI tools,
 and community-extensible book sources.
+
+## Projects and websites
+
+| Name | Role | Website |
+| --- | --- | --- |
+| Open Reading | The open-source, cross-platform reader maintained in this repository | [open.xxread.top](https://open.xxread.top/) |
+| Xiaoyuan Reader | The user-facing reading product, currently available only on iOS | [xxread.top](https://xxread.top/) |
+| Xiaoyuan Reader Community | A community for reading, writing, and discussion | [community.xxread.top](https://community.xxread.top/) |
 
 ## Not a WebView wrapper — a native Flutter reading engine
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@
   </p>
 
   <p>
+    <a href="https://open.xxread.top/"><strong>开元阅读官网</strong></a> ·
+    <a href="https://community.xxread.top/">小元读书社区</a> ·
+    <a href="https://xxread.top/">小元读书（仅 iOS）</a>
+  </p>
+
+  <p>
     <a href="https://flutter.dev/"><img src="https://img.shields.io/badge/Flutter-3.x-02569B?logo=flutter&logoColor=white" alt="Flutter"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-2ea44f" alt="MIT License"></a>
     <img src="https://img.shields.io/badge/Reader_Engine-Flutter_Native-0ea5e9" alt="Flutter Native Reader Engine">
@@ -27,6 +33,14 @@
 开元阅读是一款使用 Flutter 构建的开源电子书阅读器。项目希望把阅读重新变得简单：
 书籍、进度和笔记默认留在自己的设备上，同时提供稳定排版、朗读、标注、阅读统计、
 可选 AI 辅助，以及能够由社区共同扩展的开放书源能力。
+
+## 🌐 项目与站点
+
+| 名称 | 定位 | 地址 |
+| --- | --- | --- |
+| 开元阅读 | 本仓库对应的开源、跨平台阅读器 | [open.xxread.top](https://open.xxread.top/) |
+| 小元读书 | 面向用户的阅读产品，目前仅提供 iOS 版本 | [xxread.top](https://xxread.top/) |
+| 小元读书社区 | 阅读、创作与交流社区 | [community.xxread.top](https://community.xxread.top/) |
 
 ## 🚀 不是 WebView 套壳，是 Flutter 原生阅读引擎
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: xxread
-description: "开源、跨平台、专注阅读的电子书阅读器。"
+description: "开元阅读（Open Reading）：本地优先、跨平台、开放书源的开源电子书阅读器。"
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev


### PR DESCRIPTION
## 更新内容

- 在中英文 README 顶部加入开元阅读官网、小元读书社区和小元读书官网
- 明确开元阅读是本仓库对应的跨平台开源阅读器
- 标注小元读书目前仅提供 iOS 版本
- 同步更新 pubspec 项目描述

## 站点

- https://open.xxread.top/
- https://community.xxread.top/
- https://xxread.top/

## 验证

- git diff --check
- 三个站点均返回 HTTP 200