### PR TITLE
Pin Windows release runner for pdfx build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,8 @@ jobs:
 
   windows:
     name: Windows x64
-    runs-on: windows-latest
+    # pdfx's PDFium downloader is not compatible with CMake 4 on windows-latest.
+    runs-on: windows-2022
     timeout-minutes: 45
     steps:
       - name: Check out release source


### PR DESCRIPTION
## Summary
- pin Windows release builds to windows-2022
- avoid CMake 4 incompatibility in pdfx's PDFium downloader

The failure was reproduced in release run 29147831341 on windows-latest (Windows 2025 / VS 2026).