### PR TITLE
Set repository context for release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,7 @@ jobs:
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         shell: bash
         run: |
           version="${RELEASE_TAG#v}"
@@ -244,4 +245,5 @@ jobs:
       - name: Show published assets
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: gh release view "$RELEASE_TAG"


### PR DESCRIPTION
## Summary
- set GH_REPO explicitly in the publish job
- allow gh release commands to run without a repository checkout

Fixes the publish failure in run 29148079658 after all five platform assets were built successfully.