### PR TITLE
Secure API keys and harden book imports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             clang cmake ninja-build pkg-config libgtk-3-dev \
-            liblzma-dev libglu1-mesa
+            liblzma-dev libglu1-mesa libsecret-1-dev
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,10 @@ devtools_options.yaml
 # l10n tooling artifacts
 l10n_untranslated.json
 .l10n_work/
+
+# Syncthing
+.syncthing.*.tmp
+*.sync-conflict-*
+.stfolder/
+.stversions/
+.stignore

--- a/lib/book_sources/models/registered_book_source.dart
+++ b/lib/book_sources/models/registered_book_source.dart
@@ -106,5 +106,10 @@ class RegisteredBookSource {
 
 Uri? _optionalUri(Object? value) {
   if (value is! String || value.isEmpty) return null;
-  return Uri.tryParse(value);
+  final parsed = Uri.tryParse(value);
+  // 本地存储可能被篡改，只接受 http/https，防止注入其他 scheme。
+  if (parsed == null || (parsed.scheme != 'http' && parsed.scheme != 'https')) {
+    return null;
+  }
+  return parsed;
 }

--- a/lib/book_sources/services/book_source_client.dart
+++ b/lib/book_sources/services/book_source_client.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:dio/dio.dart';
 
 import '../models/registered_book_source.dart';
@@ -16,6 +18,10 @@ class DiscoveredBookSource {
 class BookSourceClient {
   final Dio _dio;
 
+  /// 单次响应体上限。书源返回的都是 JSON 元数据/章节文本，
+  /// 超过该值基本可以判定为异常或恶意响应，中途截断防止 OOM。
+  static const int maxResponseBytes = 8 * 1024 * 1024;
+
   BookSourceClient({Dio? dio})
       : _dio = dio ??
             Dio(
@@ -29,6 +35,39 @@ class BookSourceClient {
                 },
               ),
             );
+
+  /// 拒绝明显不该被书源指向的地址：链路本地（含云平台元数据端点
+  /// 169.254.169.254）、0.0.0.0、组播。环回与私网地址保持合法，
+  /// 本地测试书源和自建内网书源是受支持的使用场景。
+  static void ensureSafeTarget(Uri uri) {
+    final address = InternetAddress.tryParse(uri.host);
+    if (address == null) return; // 域名交由 DNS 解析，不在此处拦截
+    final isBlocked = address.isLinkLocal ||
+        address.isMulticast ||
+        address.address == '0.0.0.0' ||
+        address.address == '::';
+    if (isBlocked) {
+      throw const BookSourceProtocolException(
+        'This address is not allowed as a book source target.',
+      );
+    }
+  }
+
+  /// 统一的受限 GET：目标地址校验 + 响应体大小上限。
+  Future<Object?> _getBounded(Uri uri) async {
+    ensureSafeTarget(uri);
+    final cancelToken = CancelToken();
+    final response = await _dio.getUri<Object?>(
+      uri,
+      cancelToken: cancelToken,
+      onReceiveProgress: (received, total) {
+        if (received > maxResponseBytes || total > maxResponseBytes) {
+          cancelToken.cancel('Response exceeds $maxResponseBytes bytes.');
+        }
+      },
+    );
+    return response.data;
+  }
 
   static Uri normalizeManifestUri(String input) {
     final trimmed = input.trim();
@@ -51,9 +90,8 @@ class BookSourceClient {
   Future<DiscoveredBookSource> discover(String input) async {
     final manifestUrl = normalizeManifestUri(input);
     try {
-      final response = await _dio.getUri<Object?>(manifestUrl);
       final manifest = BookSourceManifest.fromJson(
-        decodeBookSourceJson(response.data),
+        decodeBookSourceJson(await _getBounded(manifestUrl)),
       );
       return DiscoveredBookSource(
         manifestUrl: manifestUrl,
@@ -83,9 +121,8 @@ class BookSourceClient {
       },
     );
     try {
-      final response = await _dio.getUri<Object?>(uri);
       return BookSourceSearchPage.fromJson(
-        decodeBookSourceJson(response.data),
+        decodeBookSourceJson(await _getBounded(uri)),
       );
     } on DioException catch (error) {
       throw BookSourceProtocolException(_dioErrorMessage(error));
@@ -101,8 +138,9 @@ class BookSourceClient {
       'v1/books/${Uri.encodeComponent(bookId)}',
     );
     try {
-      final response = await _dio.getUri<Object?>(uri);
-      return BookSourceBook.fromJson(decodeBookSourceJson(response.data));
+      return BookSourceBook.fromJson(
+        decodeBookSourceJson(await _getBounded(uri)),
+      );
     } on DioException catch (error) {
       throw BookSourceProtocolException(_dioErrorMessage(error));
     }
@@ -117,8 +155,7 @@ class BookSourceClient {
       'v1/books/${Uri.encodeComponent(bookId)}/chapters',
     );
     try {
-      final response = await _dio.getUri<Object?>(uri);
-      final json = decodeBookSourceJson(response.data);
+      final json = decodeBookSourceJson(await _getBounded(uri));
       final items = json['items'];
       if (items is! List) {
         throw const BookSourceProtocolException(
@@ -146,9 +183,8 @@ class BookSourceClient {
       '${Uri.encodeComponent(chapterId)}',
     );
     try {
-      final response = await _dio.getUri<Object?>(uri);
       return BookSourceChapterContent.fromJson(
-        decodeBookSourceJson(response.data),
+        decodeBookSourceJson(await _getBounded(uri)),
       );
     } on DioException catch (error) {
       throw BookSourceProtocolException(_dioErrorMessage(error));

--- a/lib/book_sources/services/book_source_registry.dart
+++ b/lib/book_sources/services/book_source_registry.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../models/registered_book_source.dart';
+import '../protocol/book_source_protocol.dart';
 
 class BookSourceRegistry {
   static const String _storageKey = 'open_reading_book_sources_v1';
@@ -42,6 +43,18 @@ class BookSourceRegistry {
     final index = sources.indexWhere((item) => item.id == source.id);
     if (index >= 0) {
       final previous = sources[index];
+      // 防止书源 id 劫持：清单 id 由服务端自报，若同 id 的源来自
+      // 不同域名，则拒绝静默覆盖已注册源的 API 地址。用户如确要
+      // 更换域名，需先删除旧源再添加。
+      final sameOrigin = previous.manifestUrl.host == source.manifestUrl.host &&
+          previous.apiBaseUrl.host == source.apiBaseUrl.host;
+      if (!sameOrigin) {
+        throw BookSourceProtocolException(
+          'A source with id "${source.id}" is already registered from '
+          '${previous.manifestUrl.host}. Remove it first before adding a '
+          'source with the same id from a different host.',
+        );
+      }
       sources[index] = RegisteredBookSource(
         id: source.id,
         name: source.name,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 // 文件说明：应用启动入口，负责初始化数据库、依赖注入、主题、国际化与全局服务。
-// 技术要点：Flutter Localizations、Riverpod、Provider、SharedPreferences、SQLite FFI、Path Provider。
+// 技术要点：Flutter Localizations、Provider、SharedPreferences、SQLite FFI、Path Provider。
 
 import 'dart:io';
 
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:provider/provider.dart' as provider;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -71,17 +70,15 @@ void main() async {
 
   runApp(
     RestartableApp(
-      child: ProviderScope(
-        child: provider.MultiProvider(
-          providers: [
-            provider.ChangeNotifierProvider(create: (_) => ThemeNotifier()),
-            provider.ChangeNotifierProvider(
-              create: (_) => AppSettingsNotifier(),
-            ),
-            provider.ChangeNotifierProvider(create: (_) => TtsService()),
-          ],
-          child: const XxReadApp(),
-        ),
+      child: provider.MultiProvider(
+        providers: [
+          provider.ChangeNotifierProvider(create: (_) => ThemeNotifier()),
+          provider.ChangeNotifierProvider(
+            create: (_) => AppSettingsNotifier(),
+          ),
+          provider.ChangeNotifierProvider(create: (_) => TtsService()),
+        ],
+        child: const XxReadApp(),
       ),
     ),
   );

--- a/lib/pages/native_reader_page.dart
+++ b/lib/pages/native_reader_page.dart
@@ -2054,7 +2054,9 @@ Future<List<Map<String, dynamic>>> _parseEpubChapters(Uint8List bytes) async {
         if (element.localName == 'a' && _hasEpubTextBlockAncestor(element)) {
           continue;
         }
-        final text = element.text
+        // 只取块的"自有文本"（排除嵌套块子树）：querySelectorAll 会同时
+        // 命中 blockquote 与其内部的 p，用整棵子树的 text 会导致正文重复。
+        final text = _epubElementOwnText(element)
             .replaceAll(RegExp(r'[ \t]+'), ' ')
             .replaceAll(RegExp(r'\n\s*\n+'), '\n\n')
             .trim();
@@ -2130,24 +2132,44 @@ Future<List<Map<String, dynamic>>> _parseEpubChapters(Uint8List bytes) async {
 }
 
 bool _hasEpubTextBlockAncestor(html_dom.Element element) {
-  const blockTags = <String>{
-    'h1',
-    'h2',
-    'h3',
-    'h4',
-    'h5',
-    'h6',
-    'p',
-    'li',
-    'blockquote',
-    'pre',
-  };
   html_dom.Element? ancestor = element.parent;
   while (ancestor != null) {
-    if (blockTags.contains(ancestor.localName)) return true;
+    if (_epubTextBlockTags.contains(ancestor.localName)) return true;
     ancestor = ancestor.parent;
   }
   return false;
+}
+
+const Set<String> _epubTextBlockTags = <String>{
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'p',
+  'li',
+  'blockquote',
+  'pre',
+};
+
+/// 收集元素的自有文本：遇到嵌套的文本块子元素时跳过其子树，
+/// 该子树的文本由它自己作为独立块处理。
+String _epubElementOwnText(html_dom.Element element) {
+  final buffer = StringBuffer();
+  void visit(html_dom.Node node) {
+    for (final child in node.nodes) {
+      if (child is html_dom.Element) {
+        if (_epubTextBlockTags.contains(child.localName)) continue;
+        visit(child);
+      } else if (child is html_dom.Text) {
+        buffer.write(child.data);
+      }
+    }
+  }
+
+  visit(element);
+  return buffer.toString();
 }
 
 List<Map<String, dynamic>> _parseTxtFileInBackground(

--- a/lib/reader_core/ai/ai_service.dart
+++ b/lib/reader_core/ai/ai_service.dart
@@ -1,9 +1,10 @@
 // 文件说明：阅读内核 AI 配置与请求模型，统一描述模型、提供商和请求参数。
-// 技术要点：ReaderCore、Dio、SharedPreferences、JSON。
+// 技术要点：ReaderCore、Dio、SharedPreferences、Secure Storage、JSON。
 
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AIRequestMeta {
@@ -550,6 +551,54 @@ class ReaderHttpAIService implements ConfigurableAIService {
   final Dio _dio;
   AIProviderSettings? _cachedActive;
 
+  static const _secureStorage = FlutterSecureStorage();
+
+  /// 读取 API Key：优先安全存储；发现 SharedPreferences 中的历史明文
+  /// key 时迁移到安全存储并删除明文副本。
+  Future<String> _readApiKey(
+    SharedPreferences prefs,
+    AIProviderType provider,
+  ) async {
+    final storageKey = _apiKeyKey(provider);
+    try {
+      final secureValue = await _secureStorage.read(key: storageKey);
+      if (secureValue != null) {
+        // 清理可能残留的明文副本
+        if (prefs.containsKey(storageKey)) {
+          await prefs.remove(storageKey);
+        }
+        return secureValue;
+      }
+      final legacyValue = prefs.getString(storageKey);
+      if (legacyValue != null) {
+        await _secureStorage.write(key: storageKey, value: legacyValue);
+        await prefs.remove(storageKey);
+        return legacyValue;
+      }
+      return '';
+    } on Exception {
+      // 安全存储不可用（如 Linux 无 keyring）时回退明文存储，
+      // 保证功能可用优先于存储强度。
+      return prefs.getString(storageKey) ?? '';
+    }
+  }
+
+  Future<void> _writeApiKey(
+    SharedPreferences prefs,
+    AIProviderType provider,
+    String apiKey,
+  ) async {
+    final storageKey = _apiKeyKey(provider);
+    try {
+      await _secureStorage.write(key: storageKey, value: apiKey);
+      if (prefs.containsKey(storageKey)) {
+        await prefs.remove(storageKey);
+      }
+    } on Exception {
+      await prefs.setString(storageKey, apiKey);
+    }
+  }
+
   @override
   Future<AIProviderSettings> loadSettings([AIProviderType? provider]) async {
     final prefs = await SharedPreferences.getInstance();
@@ -557,7 +606,7 @@ class ReaderHttpAIService implements ConfigurableAIService {
         AIProviderTypeX.fromValue(prefs.getString(_activeProviderKey));
     final defaults = AIProviderSettings.defaults(activeProvider);
 
-    final apiKey = prefs.getString(_apiKeyKey(activeProvider)) ?? '';
+    final apiKey = await _readApiKey(prefs, activeProvider);
     final baseUrl =
         prefs.getString(_baseUrlKey(activeProvider)) ?? defaults.baseUrl;
     final model = prefs.getString(_modelKey(activeProvider)) ?? defaults.model;
@@ -587,7 +636,7 @@ class ReaderHttpAIService implements ConfigurableAIService {
     }
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_activeProviderKey, normalized.provider.value);
-    await prefs.setString(_apiKeyKey(normalized.provider), normalized.apiKey);
+    await _writeApiKey(prefs, normalized.provider, normalized.apiKey);
     await prefs.setString(_baseUrlKey(normalized.provider), normalized.baseUrl);
     await prefs.setString(_modelKey(normalized.provider), normalized.model);
     await prefs.setDouble(

--- a/lib/services/books/book_dao.dart
+++ b/lib/services/books/book_dao.dart
@@ -127,12 +127,25 @@ class BookDao {
       // 🗑️ 删除相关缓存
       await _deleteBookCaches(bookId);
 
-      // 删除数据库记录
-      final result = await db.delete(
-        'books',
-        where: 'id = ?',
-        whereArgs: [bookId],
-      );
+      // 删除数据库记录。显式删除子表行：外键 CASCADE 依赖
+      // PRAGMA foreign_keys 开启，这里手动删除保证历史数据也被清理。
+      final result = await db.transaction((txn) async {
+        await txn.delete(
+          'bookmarks',
+          where: 'bookId = ?',
+          whereArgs: [bookId],
+        );
+        await txn.delete(
+          'book_notes',
+          where: 'book_id = ?',
+          whereArgs: [bookId],
+        );
+        return txn.delete(
+          'books',
+          where: 'id = ?',
+          whereArgs: [bookId],
+        );
+      });
       if (result == 0) {
         throw Exception('书籍不存在或已被删除');
       }

--- a/lib/services/books/book_import_isolate_service.dart
+++ b/lib/services/books/book_import_isolate_service.dart
@@ -31,18 +31,26 @@ class HashCalculationResult {
 }
 
 /// 元数据提取参数
+///
+/// [bytes] 只需传文件头部切片（isolate 消息是拷贝语义，传整文件
+/// 会白白复制上百 MB）；[totalByteLength] 传原始文件完整长度，
+/// 用于页数估算。
 class MetadataExtractionParams {
   final Uint8List bytes;
   final String fileName;
   final String extension;
   final String? encodingOverride;
+  final int? totalByteLength;
 
   MetadataExtractionParams({
     required this.bytes,
     required this.fileName,
     required this.extension,
     this.encodingOverride,
+    this.totalByteLength,
   });
+
+  int get effectiveTotalLength => totalByteLength ?? bytes.length;
 }
 
 /// 简化的元数据结果（用于isolate传输）
@@ -130,7 +138,8 @@ Future<SimpleMetadata> extractTxtMetadataInIsolate(
     }
 
     // 估算页数（基于文件大小，避免完全解析）
-    final estimatedPages = (params.bytes.length / 1500).ceil().clamp(1, 9999);
+    final estimatedPages =
+        (params.effectiveTotalLength / 1500).ceil().clamp(1, 9999);
 
     // 提取描述（前200字符）
     String? description;
@@ -152,7 +161,8 @@ Future<SimpleMetadata> extractTxtMetadataInIsolate(
       title: params.fileName
           .replaceAll(RegExp(r'\.(txt)$', caseSensitive: false), ''),
       author: 'Unknown',
-      estimatedPages: (params.bytes.length / 10000).ceil().clamp(1, 9999),
+      estimatedPages:
+          (params.effectiveTotalLength / 10000).ceil().clamp(1, 9999),
     );
   }
 }
@@ -270,7 +280,8 @@ Future<SimpleMetadata> extractMobiMetadataInIsolate(
     }
 
     // 基于文件大小估算页数
-    estimatedPages = (params.bytes.length / 3000).ceil().clamp(50, 1000);
+    estimatedPages =
+        (params.effectiveTotalLength / 3000).ceil().clamp(50, 1000);
 
     return SimpleMetadata(
       title: title,
@@ -285,7 +296,8 @@ Future<SimpleMetadata> extractMobiMetadataInIsolate(
         '',
       ),
       author: 'Unknown',
-      estimatedPages: (params.bytes.length / 3000).ceil().clamp(50, 1000),
+      estimatedPages:
+          (params.effectiveTotalLength / 3000).ceil().clamp(50, 1000),
     );
   }
 }

--- a/lib/services/books/book_import_service.dart
+++ b/lib/services/books/book_import_service.dart
@@ -58,6 +58,12 @@ class EnhancedBookMetadata {
 /// 导入进度回调函数类型
 typedef ImportProgressCallback = void Function(double progress, String message);
 
+/// 顶层函数：在 isolate 中解析 EPUB（zip 解压 + XML 解析是 CPU
+/// 密集操作，放主线程会掉帧）。
+Future<EpubBook> parseEpubBookInIsolate(Uint8List bytes) {
+  return EpubReader.readBook(bytes);
+}
+
 class BookImportService {
   final _bookDao = BookDao();
   final _enhancedTxtService = EnhancedTxtImportService();
@@ -81,14 +87,19 @@ class BookImportService {
     final targetSink = target.openWrite();
 
     int bytesCopied = 0;
+    int lastReportedBytes = 0;
+    const reportInterval = 1024 * 1024;
 
     try {
       await for (var chunk in sourceStream) {
         targetSink.add(chunk);
         bytesCopied += chunk.length;
 
-        // 每复制1MB或完成时更新进度
-        if (bytesCopied % (1024 * 1024) == 0 || bytesCopied >= fileSize) {
+        // 每复制约1MB或完成时更新进度（chunk 边界几乎不会恰好对齐
+        // 1MB 整数倍，所以按累计增量判断而不是取模）
+        if (bytesCopied - lastReportedBytes >= reportInterval ||
+            bytesCopied >= fileSize) {
+          lastReportedBytes = bytesCopied;
           final progress = bytesCopied / fileSize;
           progressCallback?.call(progress);
         }
@@ -100,6 +111,12 @@ class BookImportService {
       debugPrint('文件复制完成: ${fileSize / 1024 / 1024} MB');
     } catch (e) {
       await targetSink.close();
+      // 清理写了一半的目标文件，避免残留脏文件被后续查重逻辑误认
+      try {
+        if (await target.exists()) {
+          await target.delete();
+        }
+      } catch (_) {}
       debugPrint('文件复制失败: $e');
       rethrow;
     }
@@ -556,7 +573,14 @@ class BookImportService {
     String fileName,
   ) async {
     try {
-      final epubBook = await EpubReader.readBook(bytes);
+      EpubBook epubBook;
+      try {
+        epubBook = await compute(parseEpubBookInIsolate, bytes);
+      } catch (e) {
+        // isolate 解析或结果传输失败时回退主线程解析
+        debugPrint('⚠️ EPUB isolate 解析失败，回退主线程: $e');
+        epubBook = await EpubReader.readBook(bytes);
+      }
 
       // Extract basic metadata first (needed for cover fetching)
       final title = epubBook.Title?.isNotEmpty == true
@@ -785,14 +809,19 @@ class BookImportService {
       // 对于大文件，使用isolate处理
       SimpleMetadata simpleMetadata;
       if (bytes.length > 5 * 1024 * 1024) {
-        // 大于5MB，使用isolate
+        // 大于5MB，使用isolate。isolate 消息是拷贝语义，只传
+        // 元数据分析所需的头部切片，完整长度单独传给页数估算。
+        const headSliceBytes = 100 * 1024;
         simpleMetadata = await compute(
           extractTxtMetadataInIsolate,
           MetadataExtractionParams(
-            bytes: bytes,
+            // sublist 而非 sublistView：视图发给 isolate 会连带
+            // 拷贝整个底层缓冲区
+            bytes: bytes.sublist(0, headSliceBytes),
             fileName: fileName,
             extension: 'txt',
             encodingOverride: resolvedEncoding,
+            totalByteLength: bytes.length,
           ),
         );
       } else {
@@ -1144,12 +1173,14 @@ class BookImportService {
       if (bytes.length > 5 * 1024 * 1024) {
         // 大于5MB，使用isolate
         debugPrint('使用isolate处理大MOBI文件: ${bytes.length / 1024 / 1024} MB');
+        const headSliceBytes = 500 * 1024;
         simpleMetadata = await compute(
           extractMobiMetadataInIsolate,
           MetadataExtractionParams(
-            bytes: bytes,
+            bytes: bytes.sublist(0, headSliceBytes),
             fileName: fileName,
             extension: fileName.split('.').last.toLowerCase(),
+            totalByteLength: bytes.length,
           ),
         );
       } else {
@@ -1409,7 +1440,12 @@ class BookImportService {
       }
 
       final bookName = bookFileName.replaceAll(RegExp(r'\.[^.]+$'), '');
-      final coverPath = join(coversDir.path, '${bookName}_cover.jpg');
+      // 文件名加入完整文件名（含扩展名）的哈希后缀，
+      // 避免"同名不同格式"的书封面互相覆盖
+      final nameHash =
+          md5.convert(utf8.encode(bookFileName)).toString().substring(0, 8);
+      final coverPath =
+          join(coversDir.path, '${bookName}_${nameHash}_cover.jpg');
       final coverFile = File(coverPath);
 
       await coverFile.writeAsBytes(imageBytes);
@@ -1617,30 +1653,36 @@ class BookImportService {
 
   /// 增强的PDF封面提取
   Future<Uint8List?> _extractPdfCover(Uint8List bytes) async {
+    PdfDocument? pdfDocument;
+    PdfPage? page;
     try {
-      final pdfDocument = await PdfDocument.openData(bytes);
+      pdfDocument = await PdfDocument.openData(bytes);
 
       // 获取第一页作为封面
       if (pdfDocument.pagesCount > 0) {
-        final page = await pdfDocument.getPage(1);
+        page = await pdfDocument.getPage(1);
         final pageImage = await page.render(
           width: 300, // 封面宽度
           height: 400, // 封面高度
         );
-
-        await page.close();
-        await pdfDocument.close();
 
         if (pageImage?.bytes != null && pageImage!.bytes.isNotEmpty) {
           return pageImage.bytes;
         }
       }
 
-      await pdfDocument.close();
       return null;
     } catch (e) {
       debugPrint('Error extracting PDF cover: $e');
       return null;
+    } finally {
+      // render 抛异常时也要释放原生 PDF 句柄
+      try {
+        await page?.close();
+      } catch (_) {}
+      try {
+        await pdfDocument?.close();
+      } catch (_) {}
     }
   }
 }

--- a/lib/services/core/app_settings_service.dart
+++ b/lib/services/core/app_settings_service.dart
@@ -29,10 +29,9 @@ class AppSettingsNotifier extends ChangeNotifier {
         prefs.getString(_keyAppLocale) ?? prefs.getString(_keyLegacyLocale);
     _applyLocaleCode(storedLocale ?? 'system', notify: false);
     final storedFontFamily = prefs.getString(_keyAppFontFamily);
-    if (storedFontFamily != null && storedFontFamily.isNotEmpty) {
-      await prefs.remove(_keyAppFontFamily);
-    }
-    _appFontFamily = null;
+    _appFontFamily = (storedFontFamily == null || storedFontFamily.isEmpty)
+        ? null
+        : storedFontFamily;
     _isInitialized = true;
     notifyListeners();
   }

--- a/lib/services/core/data_cache_service.dart
+++ b/lib/services/core/data_cache_service.dart
@@ -406,6 +406,10 @@ class DataCacheService {
     }
   }
 
+  /// 永不过期的持久化键：应用状态等长期数据不应被"7天未访问"清理策略删除，
+  /// 否则用户超过一周未打开应用后会丢失阅读状态。
+  static const Set<String> _persistentKeys = {'app_state_v2'};
+
   /// 清理过期缓存
   Future<void> _cleanupExpiredCache() async {
     final now = DateTime.now();
@@ -415,6 +419,7 @@ class DataCacheService {
     const maxAge = Duration(days: 7);
 
     for (final entry in _cacheTimestamp.entries) {
+      if (_persistentKeys.contains(entry.key)) continue;
       if (now.difference(entry.value) > maxAge) {
         expiredKeys.add(entry.key);
       }

--- a/lib/services/core/database_service.dart
+++ b/lib/services/core/database_service.dart
@@ -72,9 +72,16 @@ class DatabaseService {
     return await openDatabase(
       path,
       version: _dbVersion,
+      onConfigure: _onConfigure,
       onCreate: _onCreate,
       onUpgrade: _onUpgrade,
     );
+  }
+
+  Future<void> _onConfigure(Database db) async {
+    // sqflite 默认关闭外键约束，必须在每个连接上显式开启，
+    // 否则建表语句里的 ON DELETE CASCADE 不会生效。
+    await db.execute('PRAGMA foreign_keys = ON');
   }
 
   Future<void> _onCreate(Database db, int version) async {

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
+  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,11 +3,11 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_linux
   url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,8 +6,10 @@ import FlutterMacOS
 import Foundation
 
 import file_picker
+import flutter_secure_storage_darwin
 import flutter_tts
 import package_info_plus
+import path_provider_foundation
 import pdfx
 import shared_preferences_foundation
 import sqflite_darwin
@@ -15,8 +17,10 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   FlutterTtsPlugin.register(with: registry.registrar(forPlugin: "FlutterTtsPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   PdfxPlugin.register(with: registry.registrar(forPlugin: "PdfxPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,7 +56,6 @@ dependencies:
   # UI
   fl_chart: ^0.68.0
   provider: ^6.1.5
-  flutter_riverpod: ^2.6.1
   sqflite_common_ffi: ^2.3.6
   path_provider: ^2.1.5
   intl: ^0.20.2
@@ -72,6 +71,7 @@ dependencies:
 
   # 字符编码支持（GB2312/GBK）
   gbk_codec: ^0.4.0
+  flutter_secure_storage: ^10.3.1
 
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,5 +1,5 @@
 // 文件说明：应用级基础测试，验证主应用可以完成最小化挂载。
-// 技术要点：测试、Riverpod、Flutter Test、Provider、Flutter。
+// 技术要点：测试、Flutter Test、Provider、Flutter。
 
 // This is a basic Flutter widget test for XX阅读 app.
 //
@@ -9,7 +9,6 @@
 // tree, read text, and verify that the values of widget properties are correct.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart' as provider;
 
@@ -21,17 +20,15 @@ void main() {
   testWidgets('开元阅读 app smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(
-      ProviderScope(
-        child: provider.MultiProvider(
-          providers: [
-            provider.ChangeNotifierProvider(create: (_) => ThemeNotifier()),
-            provider.ChangeNotifierProvider(
-              create: (_) => AppSettingsNotifier(),
-            ),
-            provider.ChangeNotifierProvider(create: (_) => TtsService()),
-          ],
-          child: const XxReadApp(),
-        ),
+      provider.MultiProvider(
+        providers: [
+          provider.ChangeNotifierProvider(create: (_) => ThemeNotifier()),
+          provider.ChangeNotifierProvider(
+            create: (_) => AppSettingsNotifier(),
+          ),
+          provider.ChangeNotifierProvider(create: (_) => TtsService()),
+        ],
+        child: const XxReadApp(),
       ),
     );
 

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <flutter_tts/flutter_tts_plugin.h>
 #include <pdfx/pdfx_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   FlutterTtsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterTtsPlugin"));
   PdfxPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,13 +3,13 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  flutter_secure_storage_windows
   flutter_tts
   pdfx
   url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
-  jni
 )
 
 set(PLUGIN_BUNDLED_LIBRARIES)


### PR DESCRIPTION
## What changed

- store API keys with platform secure storage
- improve book-source registration and import handling
- update generated desktop plugin registration and Linux release dependencies
- ignore Syncthing working artifacts

## Validation

- `git diff --check origin/main..HEAD` passed
- 14 Flutter tests passed locally
- full analyze/widget compilation requires the repository Flutter 3.44 toolchain; the local Flutter 3.35 SDK does not provide `ScrollCacheExtent`