### PR TITLE
NOJIRA: Add discovery browsing and source management

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -93,7 +93,7 @@ chapter-content endpoints. Reader apps implement the protocol once; source
 developers may use any server language or framework.
 
 - Repository: [miloquinn/open-reading-source-protocol](https://github.com/miloquinn/open-reading-source-protocol)
-- Version: `1.0` early public draft
+- Version: `1.1` discovery candidate
 - Intended content: original, public-domain, or properly licensed works
 
 Run the local example source:

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@
 
 - 协议仓库：**[miloquinn/open-reading-source-protocol](https://github.com/miloquinn/open-reading-source-protocol)**
 - 协议名称：Open Reading Source Protocol
-- 当前版本：`1.0` 早期公开草案
+- 当前版本：`1.1` 发现能力候选版
 - 适用范围：原创、公共领域或已获得合法授权的内容
 
 开发者可以直接搭建原生 ORSP 服务，也可以为自己有权使用的现有内容服务编写适配网关。

--- a/docs/book-source-openapi.yaml
+++ b/docs/book-source-openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Open Reading Source Protocol
-  version: 1.0.0
+  version: 1.1.0
   description: Standard API implemented by an Open Reading compatible book source.
 servers:
   - url: https://books.example.org/api

--- a/docs/book-source-openapi.yaml
+++ b/docs/book-source-openapi.yaml
@@ -6,6 +6,52 @@ info:
 servers:
   - url: https://books.example.org/api
 paths:
+  /v1/discover:
+    get:
+      operationId: discoverBooks
+      responses:
+        '200':
+          description: Curated discovery shelves
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/DiscoveryPage' }
+  /v1/categories:
+    get:
+      operationId: listCategories
+      responses:
+        '200':
+          description: Browseable categories
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [items]
+                properties:
+                  items:
+                    type: array
+                    items: { $ref: '#/components/schemas/Category' }
+  /v1/browse:
+    get:
+      operationId: browseBooks
+      parameters:
+        - name: category
+          in: query
+          schema: { type: string, maxLength: 200 }
+        - name: sort
+          in: query
+          schema: { type: string, enum: [popular, latest], default: latest }
+        - name: page
+          in: query
+          schema: { type: integer, minimum: 1, default: 1 }
+        - name: pageSize
+          in: query
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+      responses:
+        '200':
+          description: Browse results
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/SearchPage' }
   /v1/search:
     get:
       operationId: searchBooks
@@ -111,6 +157,28 @@ components:
         pageSize: { type: integer, minimum: 0 }
         total: { type: integer, minimum: 0 }
         hasMore: { type: boolean }
+    DiscoveryPage:
+      type: object
+      required: [sections]
+      properties:
+        sections:
+          type: array
+          items: { $ref: '#/components/schemas/DiscoverySection' }
+    DiscoverySection:
+      type: object
+      required: [id, title, items]
+      properties:
+        id: { type: string, minLength: 1 }
+        title: { type: string, minLength: 1 }
+        items:
+          type: array
+          items: { $ref: '#/components/schemas/Book' }
+    Category:
+      type: object
+      required: [id, name]
+      properties:
+        id: { type: string, minLength: 1 }
+        name: { type: string, minLength: 1 }
     Chapter:
       type: object
       required: [id, title, order]

--- a/docs/book-source-protocol-v1.md
+++ b/docs/book-source-protocol-v1.md
@@ -36,7 +36,7 @@ GET /.well-known/open-reading-source.json
   "iconUrl": "https://books.example.org/icon.png",
   "websiteUrl": "https://books.example.org/",
   "languages": ["zh-CN", "en"],
-  "capabilities": ["search", "detail", "catalog", "content"]
+  "capabilities": ["search", "discover", "categories", "browse", "detail", "catalog", "content"]
 }
 ```
 
@@ -50,6 +50,9 @@ GET /.well-known/open-reading-source.json
 | `name` | 展示名称 |
 | `apiBaseUrl` | API 根地址，必须是绝对 HTTP(S) URL |
 | `capabilities` | 能力列表；v1 必须包含 `search` |
+
+发现相关能力均为可选能力：`discover` 提供分区推荐，`categories` 提供分类定义，
+`browse` 提供分类或排序浏览。未声明这些能力的旧书源仍可正常参与搜索。
 
 ## 3. 通用约定
 
@@ -93,7 +96,38 @@ GET /v1/search?q={query}&page=1&pageSize=20
 }
 ```
 
-### 4.2 书籍详情
+### 4.2 发现（可选）
+
+声明 `discover` 能力的书源实现：
+
+```text
+GET /v1/discover
+```
+
+响应包含 `sections` 数组，每个分区具有稳定 `id`、展示标题 `title` 和书籍数组 `items`。
+
+### 4.3 分类（可选）
+
+声明 `categories` 能力的书源实现：
+
+```text
+GET /v1/categories
+```
+
+响应格式为 `{"items":[{"id":"literature","name":"文学"}]}`。若分类需要展示书籍，
+该书源还应声明 `browse` 能力。
+
+### 4.4 浏览（可选）
+
+声明 `browse` 能力的书源实现：
+
+```text
+GET /v1/browse?category={categoryId}&sort=latest&page=1&pageSize=20
+```
+
+`category` 可省略；`sort` 首版约定支持 `latest` 和 `popular`。响应沿用搜索分页结构。
+
+### 4.5 书籍详情
 
 ```text
 GET /v1/books/{bookId}
@@ -101,7 +135,7 @@ GET /v1/books/{bookId}
 
 响应使用与搜索项相同的书籍对象，可返回更完整的 `description` 和分类信息。
 
-### 4.3 章节目录
+### 4.6 章节目录
 
 ```text
 GET /v1/books/{bookId}/chapters
@@ -120,7 +154,7 @@ GET /v1/books/{bookId}/chapters
 }
 ```
 
-### 4.4 章节正文
+### 4.7 章节正文
 
 ```text
 GET /v1/books/{bookId}/chapters/{chapterId}

--- a/docs/book-source-protocol-v1.md
+++ b/docs/book-source-protocol-v1.md
@@ -1,4 +1,4 @@
-# Open Reading Source Protocol v1.0
+# Open Reading Source Protocol v1.1
 
 Open Reading Source Protocol（ORSP）是一套面向电子书与连载文本的开放 HTTP
 协议。它把阅读器与具体内容站点解耦：阅读器只实现一次协议客户端，内容提供方或适配器
@@ -28,7 +28,7 @@ GET /.well-known/open-reading-source.json
 ```json
 {
   "protocol": "open-reading-source",
-  "protocolVersion": "1.0",
+  "protocolVersion": "1.1",
   "id": "org.example.public-books",
   "name": "Example Public Books",
   "description": "Public-domain books maintained by Example.org",
@@ -58,7 +58,7 @@ GET /.well-known/open-reading-source.json
 
 - 请求与响应编码为 UTF-8。
 - JSON 响应使用 `application/json`。
-- 客户端发送 `X-Open-Reading-Protocol: 1.0`。
+- 客户端发送 `X-Open-Reading-Protocol: 1.1`。
 - ID 是书源内部稳定、不透明的字符串。客户端不得推断 ID 格式。
 - 时间使用 ISO 8601，例如 `2026-07-11T10:00:00Z`。
 - 章节正文 `contentType` 仅允许 `text/plain`、`text/markdown`、`text/html`。
@@ -232,4 +232,4 @@ dart run tool/example_book_source_server.dart --host 0.0.0.0 --port 8788 \
 ```
 
 协议文本与参考实现随 Open Reading 项目按仓库许可证开放。建议第三方实现明确标注支持的
-协议版本，例如 `Open Reading Source Protocol 1.0 compatible`。
+协议版本，例如 `Open Reading Source Protocol 1.1 compatible`。

--- a/docs/examples/open-reading-source.json
+++ b/docs/examples/open-reading-source.json
@@ -1,6 +1,6 @@
 {
   "protocol": "open-reading-source",
-  "protocolVersion": "1.0",
+  "protocolVersion": "1.1",
   "id": "org.example.public-books",
   "name": "Example Public Books",
   "description": "A minimal Open Reading compatible source",

--- a/docs/examples/open-reading-source.json
+++ b/docs/examples/open-reading-source.json
@@ -8,5 +8,13 @@
   "iconUrl": "https://books.example.org/icon.png",
   "websiteUrl": "https://books.example.org/",
   "languages": ["zh-CN", "en"],
-  "capabilities": ["search", "detail", "catalog", "content"]
+  "capabilities": [
+    "search",
+    "discover",
+    "categories",
+    "browse",
+    "detail",
+    "catalog",
+    "content"
+  ]
 }

--- a/lib/book_sources/protocol/book_source_protocol.dart
+++ b/lib/book_sources/protocol/book_source_protocol.dart
@@ -126,6 +126,70 @@ class BookSourceSearchPage {
   }
 }
 
+/// A curated shelf returned by an optional discovery-capable source.
+class BookSourceDiscoverySection {
+  final String id;
+  final String title;
+  final List<BookSourceBook> items;
+
+  const BookSourceDiscoverySection({
+    required this.id,
+    required this.title,
+    required this.items,
+  });
+
+  factory BookSourceDiscoverySection.fromJson(Map<String, dynamic> json) {
+    final rawItems = json['items'];
+    if (rawItems is! List) {
+      throw const BookSourceProtocolException(
+        'Discovery section must contain an items array.',
+      );
+    }
+    return BookSourceDiscoverySection(
+      id: _requiredString(json, 'id'),
+      title: _requiredString(json, 'title'),
+      items: rawItems
+          .map((item) => BookSourceBook.fromJson(_jsonMap(item)))
+          .toList(growable: false),
+    );
+  }
+}
+
+class BookSourceDiscoveryPage {
+  final List<BookSourceDiscoverySection> sections;
+
+  const BookSourceDiscoveryPage({required this.sections});
+
+  factory BookSourceDiscoveryPage.fromJson(Map<String, dynamic> json) {
+    final rawSections = json['sections'];
+    if (rawSections is! List) {
+      throw const BookSourceProtocolException(
+        'Discovery response must contain a sections array.',
+      );
+    }
+    return BookSourceDiscoveryPage(
+      sections: rawSections
+          .map((section) =>
+              BookSourceDiscoverySection.fromJson(_jsonMap(section)))
+          .toList(growable: false),
+    );
+  }
+}
+
+class BookSourceCategory {
+  final String id;
+  final String name;
+
+  const BookSourceCategory({required this.id, required this.name});
+
+  factory BookSourceCategory.fromJson(Map<String, dynamic> json) {
+    return BookSourceCategory(
+      id: _requiredString(json, 'id'),
+      name: _requiredString(json, 'name'),
+    );
+  }
+}
+
 class BookSourceBook {
   final String id;
   final String title;

--- a/lib/book_sources/protocol/book_source_protocol.dart
+++ b/lib/book_sources/protocol/book_source_protocol.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
 const String openReadingSourceProtocol = 'open-reading-source';
-const String openReadingSourceProtocolVersion = '1.0';
+const String openReadingSourceProtocolVersion = '1.1';
 const String openReadingSourceProtocolRepositoryUrl =
     'https://github.com/miloquinn/open-reading-source-protocol';
 const String openReadingSourceDiscoveryPath =

--- a/lib/book_sources/services/book_source_client.dart
+++ b/lib/book_sources/services/book_source_client.dart
@@ -140,6 +140,81 @@ class BookSourceClient {
     }
   }
 
+  Future<BookSourceDiscoveryPage> getDiscovery(
+    RegisteredBookSource source,
+  ) async {
+    if (!source.capabilities.contains('discover')) {
+      throw const BookSourceProtocolException(
+        'This source does not support discovery.',
+      );
+    }
+    final uri = _apiUri(source.apiBaseUrl, 'v1/discover');
+    try {
+      return BookSourceDiscoveryPage.fromJson(
+        decodeBookSourceJson(await _getBounded(uri)),
+      );
+    } on DioException catch (error) {
+      throw BookSourceProtocolException(_dioErrorMessage(error));
+    }
+  }
+
+  Future<List<BookSourceCategory>> getCategories(
+    RegisteredBookSource source,
+  ) async {
+    if (!source.capabilities.contains('categories')) {
+      throw const BookSourceProtocolException(
+        'This source does not support categories.',
+      );
+    }
+    final uri = _apiUri(source.apiBaseUrl, 'v1/categories');
+    try {
+      final json = decodeBookSourceJson(await _getBounded(uri));
+      final items = json['items'];
+      if (items is! List) {
+        throw const BookSourceProtocolException(
+          'Category response must contain an items array.',
+        );
+      }
+      return items
+          .map((item) => BookSourceCategory.fromJson(
+                decodeBookSourceJson(item),
+              ))
+          .toList(growable: false);
+    } on DioException catch (error) {
+      throw BookSourceProtocolException(_dioErrorMessage(error));
+    }
+  }
+
+  Future<BookSourceSearchPage> browse(
+    RegisteredBookSource source, {
+    String? category,
+    String sort = 'latest',
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    if (!source.capabilities.contains('browse')) {
+      throw const BookSourceProtocolException(
+        'This source does not support browsing.',
+      );
+    }
+    final uri = _apiUri(source.apiBaseUrl, 'v1/browse').replace(
+      queryParameters: {
+        if (category != null && category.trim().isNotEmpty)
+          'category': category.trim(),
+        'sort': sort,
+        'page': '$page',
+        'pageSize': '$pageSize',
+      },
+    );
+    try {
+      return BookSourceSearchPage.fromJson(
+        decodeBookSourceJson(await _getBounded(uri)),
+      );
+    } on DioException catch (error) {
+      throw BookSourceProtocolException(_dioErrorMessage(error));
+    }
+  }
+
   Future<BookSourceBook> getBook(
     RegisteredBookSource source,
     String bookId,

--- a/lib/book_sources/services/book_source_registry.dart
+++ b/lib/book_sources/services/book_source_registry.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:shared_preferences/shared_preferences.dart';
@@ -7,6 +8,10 @@ import '../protocol/book_source_protocol.dart';
 
 class BookSourceRegistry {
   static const String _storageKey = 'open_reading_book_sources_v1';
+  static final StreamController<void> _changesController =
+      StreamController<void>.broadcast();
+
+  Stream<void> get changes => _changesController.stream;
 
   Future<List<RegisteredBookSource>> load() async {
     final preferences = await SharedPreferences.getInstance();
@@ -73,6 +78,7 @@ class BookSourceRegistry {
       sources.add(source);
     }
     await _save(sources);
+    _changesController.add(null);
     return load();
   }
 
@@ -85,12 +91,14 @@ class BookSourceRegistry {
             source.id == id ? source.copyWith(enabled: enabled) : source)
         .toList(growable: false);
     await _save(sources);
+    _changesController.add(null);
     return load();
   }
 
   Future<List<RegisteredBookSource>> remove(String id) async {
     final sources = (await load()).where((source) => source.id != id).toList();
     await _save(sources);
+    _changesController.add(null);
     return load();
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,8 +76,8 @@
   "bookSourcesProtocolRepository": "Protocol repository",
   "bookSourcesProtocolRepositoryOpen": "View on GitHub",
   "bookSourcesProtocolRepositoryOpenFailed": "Could not open the protocol repository",
-  "bookSourcesProtocolDialogTitle": "Open source protocol v1",
-  "bookSourcesProtocolDialogBody": "A source publishes /.well-known/open-reading-source.json and implements /v1/search plus book details, chapter catalogs, and chapter content endpoints. Version 1 supports public HTTP(S) sources that do not require sign-in.",
+  "bookSourcesProtocolDialogTitle": "Open source protocol v1.1",
+  "bookSourcesProtocolDialogBody": "A source publishes /.well-known/open-reading-source.json and implements search, book details, chapter catalogs, and chapter content. Version 1.1 optionally adds discovery, categories, and browsing for public HTTP(S) sources that do not require sign-in.",
   "bookSourcesClose": "Close",
   "bookSourcesIdentity": "Source ID: {sourceId}\nBook ID: {bookId}",
   "@bookSourcesIdentity": {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -8,7 +8,7 @@
   "@home": {
     "description": "Home tab label"
   },
-  "library": "Library",
+  "library": "Bookshelf",
   "@library": {
     "description": "Library tab label"
   },
@@ -16,6 +16,29 @@
   "@bookSources": {
     "description": "Book sources tab label"
   },
+  "discover": "Discover",
+  "discoverSubtitle": "Search and browse enabled providers to find your next book",
+  "discoverRecommended": "For you",
+  "discoverCategories": "Categories",
+  "discoverLatest": "Latest",
+  "discoverLoadFailed": "Could not load discovery content",
+  "discoverRetry": "Try again",
+  "discoverUnsupportedTitle": "Current sources do not support this section",
+  "discoverUnsupportedMessage": "A source with the {capability} capability is required. Existing sources can still be searched.",
+  "@discoverUnsupportedMessage": {
+    "placeholders": {
+      "capability": {
+        "type": "String"
+      }
+    }
+  },
+  "discoverChooseCategory": "Choose a category",
+  "discoverChooseCategoryHint": "Select a category above to browse books from that provider.",
+  "discoverCategoryEmpty": "There are no books to show in this category yet.",
+  "bookSourceManagementTitle": "Manage sources",
+  "bookSourceManagementSubtitle": "Add, enable, remove, and inspect content providers. Discovery stays focused on finding books.",
+  "settingsContentSourcesTitle": "Content sources",
+  "settingsContentSourcesSubtitle": "Add, enable, or remove open book sources",
   "bookSourcesSubtitle": "Connect open sources and search readable content across providers",
   "bookSourcesAdd": "Add source",
   "bookSourcesSearchHint": "Search enabled sources by title or author",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -64,8 +64,8 @@
   "bookSourcesProtocolRepository": "プロトコルのリポジトリ",
   "bookSourcesProtocolRepositoryOpen": "GitHub で見る",
   "bookSourcesProtocolRepositoryOpenFailed": "プロトコルのリポジトリを開けませんでした",
-  "bookSourcesProtocolDialogTitle": "オープンソースプロトコル v1",
-  "bookSourcesProtocolDialogBody": "サービスは /.well-known/open-reading-source.json でディスカバリードキュメントを公開し、/v1/search、書籍詳細、章の目次、章の本文の各エンドポイントを実装します。バージョン 1 はログイン不要の公開 HTTP(S) ソースのみをサポートします。",
+  "bookSourcesProtocolDialogTitle": "オープンソースプロトコル v1.1",
+  "bookSourcesProtocolDialogBody": "サービスは /.well-known/open-reading-source.json でディスカバリードキュメントを公開し、検索、書籍詳細、章一覧、本文取得を実装します。v1.1 では公開 HTTP(S) ソース向けにディスカバリー、カテゴリ、ブラウズを任意で追加できます。",
   "bookSourcesClose": "閉じる",
   "bookSourcesIdentity": "ソース ID：{sourceId}\n書籍 ID：{bookId}",
   "@bookSourcesIdentity": {

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -4,6 +4,29 @@
   "home": "ホーム",
   "library": "本棚",
   "bookSources": "ソース",
+  "discover": "見つける",
+  "discoverSubtitle": "有効な提供元を検索・閲覧して、次に読む本を見つけます",
+  "discoverRecommended": "おすすめ",
+  "discoverCategories": "カテゴリ",
+  "discoverLatest": "新着",
+  "discoverLoadFailed": "コンテンツを読み込めませんでした",
+  "discoverRetry": "再読み込み",
+  "discoverUnsupportedTitle": "現在のソースはこの項目に対応していません",
+  "discoverUnsupportedMessage": "{capability} 機能を持つソースが必要です。既存のソースは引き続き検索できます。",
+  "@discoverUnsupportedMessage": {
+    "placeholders": {
+      "capability": {
+        "type": "String"
+      }
+    }
+  },
+  "discoverChooseCategory": "カテゴリを選択",
+  "discoverChooseCategoryHint": "上のカテゴリを選ぶと、その提供元の書籍を閲覧できます。",
+  "discoverCategoryEmpty": "このカテゴリには表示できる書籍がまだありません。",
+  "bookSourceManagementTitle": "ソース管理",
+  "bookSourceManagementSubtitle": "コンテンツ提供元の追加、有効化、削除、プロトコル情報を管理します。",
+  "settingsContentSourcesTitle": "コンテンツソース",
+  "settingsContentSourcesSubtitle": "オープンな書籍ソースを追加、有効化、削除",
   "bookSourcesSubtitle": "オープンソースに接続し、提供元をまたいで読める本を検索",
   "bookSourcesAdd": "ソースを追加",
   "bookSourcesSearchHint": "書名や著者で有効なソースを検索",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -116,7 +116,7 @@ abstract class AppLocalizations {
   /// Library tab label
   ///
   /// In en, this message translates to:
-  /// **'Library'**
+  /// **'Bookshelf'**
   String get library;
 
   /// Book sources tab label
@@ -124,6 +124,102 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Sources'**
   String get bookSources;
+
+  /// No description provided for @discover.
+  ///
+  /// In en, this message translates to:
+  /// **'Discover'**
+  String get discover;
+
+  /// No description provided for @discoverSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Search and browse enabled providers to find your next book'**
+  String get discoverSubtitle;
+
+  /// No description provided for @discoverRecommended.
+  ///
+  /// In en, this message translates to:
+  /// **'For you'**
+  String get discoverRecommended;
+
+  /// No description provided for @discoverCategories.
+  ///
+  /// In en, this message translates to:
+  /// **'Categories'**
+  String get discoverCategories;
+
+  /// No description provided for @discoverLatest.
+  ///
+  /// In en, this message translates to:
+  /// **'Latest'**
+  String get discoverLatest;
+
+  /// No description provided for @discoverLoadFailed.
+  ///
+  /// In en, this message translates to:
+  /// **'Could not load discovery content'**
+  String get discoverLoadFailed;
+
+  /// No description provided for @discoverRetry.
+  ///
+  /// In en, this message translates to:
+  /// **'Try again'**
+  String get discoverRetry;
+
+  /// No description provided for @discoverUnsupportedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Current sources do not support this section'**
+  String get discoverUnsupportedTitle;
+
+  /// No description provided for @discoverUnsupportedMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'A source with the {capability} capability is required. Existing sources can still be searched.'**
+  String discoverUnsupportedMessage(String capability);
+
+  /// No description provided for @discoverChooseCategory.
+  ///
+  /// In en, this message translates to:
+  /// **'Choose a category'**
+  String get discoverChooseCategory;
+
+  /// No description provided for @discoverChooseCategoryHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Select a category above to browse books from that provider.'**
+  String get discoverChooseCategoryHint;
+
+  /// No description provided for @discoverCategoryEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'There are no books to show in this category yet.'**
+  String get discoverCategoryEmpty;
+
+  /// No description provided for @bookSourceManagementTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Manage sources'**
+  String get bookSourceManagementTitle;
+
+  /// No description provided for @bookSourceManagementSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add, enable, remove, and inspect content providers. Discovery stays focused on finding books.'**
+  String get bookSourceManagementSubtitle;
+
+  /// No description provided for @settingsContentSourcesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Content sources'**
+  String get settingsContentSourcesTitle;
+
+  /// No description provided for @settingsContentSourcesSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add, enable, or remove open book sources'**
+  String get settingsContentSourcesSubtitle;
 
   /// No description provided for @bookSourcesSubtitle.
   ///

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -404,13 +404,13 @@ abstract class AppLocalizations {
   /// No description provided for @bookSourcesProtocolDialogTitle.
   ///
   /// In en, this message translates to:
-  /// **'Open source protocol v1'**
+  /// **'Open source protocol v1.1'**
   String get bookSourcesProtocolDialogTitle;
 
   /// No description provided for @bookSourcesProtocolDialogBody.
   ///
   /// In en, this message translates to:
-  /// **'A source publishes /.well-known/open-reading-source.json and implements /v1/search plus book details, chapter catalogs, and chapter content endpoints. Version 1 supports public HTTP(S) sources that do not require sign-in.'**
+  /// **'A source publishes /.well-known/open-reading-source.json and implements search, book details, chapter catalogs, and chapter content. Version 1.1 optionally adds discovery, categories, and browsing for public HTTP(S) sources that do not require sign-in.'**
   String get bookSourcesProtocolDialogBody;
 
   /// No description provided for @bookSourcesClose.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -177,11 +177,11 @@ class AppLocalizationsEn extends AppLocalizations {
       'Could not open the protocol repository';
 
   @override
-  String get bookSourcesProtocolDialogTitle => 'Open source protocol v1';
+  String get bookSourcesProtocolDialogTitle => 'Open source protocol v1.1';
 
   @override
   String get bookSourcesProtocolDialogBody =>
-      'A source publishes /.well-known/open-reading-source.json and implements /v1/search plus book details, chapter catalogs, and chapter content endpoints. Version 1 supports public HTTP(S) sources that do not require sign-in.';
+      'A source publishes /.well-known/open-reading-source.json and implements search, book details, chapter catalogs, and chapter content. Version 1.1 optionally adds discovery, categories, and browsing for public HTTP(S) sources that do not require sign-in.';
 
   @override
   String get bookSourcesClose => 'Close';

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -15,10 +15,66 @@ class AppLocalizationsEn extends AppLocalizations {
   String get home => 'Home';
 
   @override
-  String get library => 'Library';
+  String get library => 'Bookshelf';
 
   @override
   String get bookSources => 'Sources';
+
+  @override
+  String get discover => 'Discover';
+
+  @override
+  String get discoverSubtitle =>
+      'Search and browse enabled providers to find your next book';
+
+  @override
+  String get discoverRecommended => 'For you';
+
+  @override
+  String get discoverCategories => 'Categories';
+
+  @override
+  String get discoverLatest => 'Latest';
+
+  @override
+  String get discoverLoadFailed => 'Could not load discovery content';
+
+  @override
+  String get discoverRetry => 'Try again';
+
+  @override
+  String get discoverUnsupportedTitle =>
+      'Current sources do not support this section';
+
+  @override
+  String discoverUnsupportedMessage(String capability) {
+    return 'A source with the $capability capability is required. Existing sources can still be searched.';
+  }
+
+  @override
+  String get discoverChooseCategory => 'Choose a category';
+
+  @override
+  String get discoverChooseCategoryHint =>
+      'Select a category above to browse books from that provider.';
+
+  @override
+  String get discoverCategoryEmpty =>
+      'There are no books to show in this category yet.';
+
+  @override
+  String get bookSourceManagementTitle => 'Manage sources';
+
+  @override
+  String get bookSourceManagementSubtitle =>
+      'Add, enable, remove, and inspect content providers. Discovery stays focused on finding books.';
+
+  @override
+  String get settingsContentSourcesTitle => 'Content sources';
+
+  @override
+  String get settingsContentSourcesSubtitle =>
+      'Add, enable, or remove open book sources';
 
   @override
   String get bookSourcesSubtitle =>

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -166,11 +166,11 @@ class AppLocalizationsJa extends AppLocalizations {
   String get bookSourcesProtocolRepositoryOpenFailed => 'プロトコルのリポジトリを開けませんでした';
 
   @override
-  String get bookSourcesProtocolDialogTitle => 'オープンソースプロトコル v1';
+  String get bookSourcesProtocolDialogTitle => 'オープンソースプロトコル v1.1';
 
   @override
   String get bookSourcesProtocolDialogBody =>
-      'サービスは /.well-known/open-reading-source.json でディスカバリードキュメントを公開し、/v1/search、書籍詳細、章の目次、章の本文の各エンドポイントを実装します。バージョン 1 はログイン不要の公開 HTTP(S) ソースのみをサポートします。';
+      'サービスは /.well-known/open-reading-source.json でディスカバリードキュメントを公開し、検索、書籍詳細、章一覧、本文取得を実装します。v1.1 では公開 HTTP(S) ソース向けにディスカバリー、カテゴリ、ブラウズを任意で追加できます。';
 
   @override
   String get bookSourcesClose => '閉じる';

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -21,6 +21,57 @@ class AppLocalizationsJa extends AppLocalizations {
   String get bookSources => 'ソース';
 
   @override
+  String get discover => '見つける';
+
+  @override
+  String get discoverSubtitle => '有効な提供元を検索・閲覧して、次に読む本を見つけます';
+
+  @override
+  String get discoverRecommended => 'おすすめ';
+
+  @override
+  String get discoverCategories => 'カテゴリ';
+
+  @override
+  String get discoverLatest => '新着';
+
+  @override
+  String get discoverLoadFailed => 'コンテンツを読み込めませんでした';
+
+  @override
+  String get discoverRetry => '再読み込み';
+
+  @override
+  String get discoverUnsupportedTitle => '現在のソースはこの項目に対応していません';
+
+  @override
+  String discoverUnsupportedMessage(String capability) {
+    return '$capability 機能を持つソースが必要です。既存のソースは引き続き検索できます。';
+  }
+
+  @override
+  String get discoverChooseCategory => 'カテゴリを選択';
+
+  @override
+  String get discoverChooseCategoryHint => '上のカテゴリを選ぶと、その提供元の書籍を閲覧できます。';
+
+  @override
+  String get discoverCategoryEmpty => 'このカテゴリには表示できる書籍がまだありません。';
+
+  @override
+  String get bookSourceManagementTitle => 'ソース管理';
+
+  @override
+  String get bookSourceManagementSubtitle =>
+      'コンテンツ提供元の追加、有効化、削除、プロトコル情報を管理します。';
+
+  @override
+  String get settingsContentSourcesTitle => 'コンテンツソース';
+
+  @override
+  String get settingsContentSourcesSubtitle => 'オープンな書籍ソースを追加、有効化、削除';
+
+  @override
   String get bookSourcesSubtitle => 'オープンソースに接続し、提供元をまたいで読める本を検索';
 
   @override

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -15,10 +15,60 @@ class AppLocalizationsZh extends AppLocalizations {
   String get home => '首页';
 
   @override
-  String get library => '书库';
+  String get library => '书架';
 
   @override
   String get bookSources => '书源';
+
+  @override
+  String get discover => '发现';
+
+  @override
+  String get discoverSubtitle => '从已启用的内容来源中搜索、浏览并发现下一本书';
+
+  @override
+  String get discoverRecommended => '推荐';
+
+  @override
+  String get discoverCategories => '分类';
+
+  @override
+  String get discoverLatest => '最新';
+
+  @override
+  String get discoverLoadFailed => '发现内容加载失败';
+
+  @override
+  String get discoverRetry => '重新加载';
+
+  @override
+  String get discoverUnsupportedTitle => '当前书源暂不支持此栏目';
+
+  @override
+  String discoverUnsupportedMessage(String capability) {
+    return '需要书源提供 $capability 能力；现有书源仍可继续用于搜索。';
+  }
+
+  @override
+  String get discoverChooseCategory => '选择一个分类';
+
+  @override
+  String get discoverChooseCategoryHint => '选择上方分类后查看该书源提供的书籍。';
+
+  @override
+  String get discoverCategoryEmpty => '这个分类暂时没有可展示的书籍。';
+
+  @override
+  String get bookSourceManagementTitle => '书源管理';
+
+  @override
+  String get bookSourceManagementSubtitle => '管理内容来源的添加、启停与协议信息。发现页只保留找书体验。';
+
+  @override
+  String get settingsContentSourcesTitle => '内容来源';
+
+  @override
+  String get settingsContentSourcesSubtitle => '添加、启用或移除开放书源';
 
   @override
   String get bookSourcesSubtitle => '连接开放书源，跨来源搜索可阅读内容';
@@ -1884,10 +1934,60 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get home => '首頁';
 
   @override
-  String get library => '書庫';
+  String get library => '書架';
 
   @override
   String get bookSources => '書源';
+
+  @override
+  String get discover => '探索';
+
+  @override
+  String get discoverSubtitle => '從已啟用的內容來源搜尋、瀏覽並找到下一本書';
+
+  @override
+  String get discoverRecommended => '推薦';
+
+  @override
+  String get discoverCategories => '分類';
+
+  @override
+  String get discoverLatest => '最新';
+
+  @override
+  String get discoverLoadFailed => '探索內容載入失敗';
+
+  @override
+  String get discoverRetry => '重新載入';
+
+  @override
+  String get discoverUnsupportedTitle => '目前書源暫不支援此欄目';
+
+  @override
+  String discoverUnsupportedMessage(String capability) {
+    return '需要書源提供 $capability 能力；現有書源仍可繼續用於搜尋。';
+  }
+
+  @override
+  String get discoverChooseCategory => '選擇一個分類';
+
+  @override
+  String get discoverChooseCategoryHint => '選擇上方分類後查看該書源提供的書籍。';
+
+  @override
+  String get discoverCategoryEmpty => '這個分類暫時沒有可顯示的書籍。';
+
+  @override
+  String get bookSourceManagementTitle => '書源管理';
+
+  @override
+  String get bookSourceManagementSubtitle => '管理內容來源的新增、啟停與協定資訊。探索頁只保留找書體驗。';
+
+  @override
+  String get settingsContentSourcesTitle => '內容來源';
+
+  @override
+  String get settingsContentSourcesSubtitle => '新增、啟用或移除開放書源';
 
   @override
   String get bookSourcesSubtitle => '連接開放書源，跨來源搜尋可閱讀內容';

--- a/lib/l10n/app_localizations_zh.dart
+++ b/lib/l10n/app_localizations_zh.dart
@@ -165,11 +165,11 @@ class AppLocalizationsZh extends AppLocalizations {
   String get bookSourcesProtocolRepositoryOpenFailed => '无法打开书源协议仓库';
 
   @override
-  String get bookSourcesProtocolDialogTitle => '开放书源协议 v1';
+  String get bookSourcesProtocolDialogTitle => '开放书源协议 v1.1';
 
   @override
   String get bookSourcesProtocolDialogBody =>
-      '服务在 /.well-known/open-reading-source.json 发布发现文档，并实现 /v1/search、书籍详情、章节目录与章节正文接口。首版仅支持公开、无需登录的 HTTP(S) 书源。';
+      '服务在 /.well-known/open-reading-source.json 发布发现文档，并实现搜索、书籍详情、章节目录与章节正文接口。v1.1 可选支持推荐、分类与浏览，仍仅面向公开、无需登录的 HTTP(S) 书源。';
 
   @override
   String get bookSourcesClose => '关闭';
@@ -2084,11 +2084,11 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get bookSourcesProtocolRepositoryOpenFailed => '無法開啟書源協定倉庫';
 
   @override
-  String get bookSourcesProtocolDialogTitle => '開放書源協定 v1';
+  String get bookSourcesProtocolDialogTitle => '開放書源協定 v1.1';
 
   @override
   String get bookSourcesProtocolDialogBody =>
-      '服務在 /.well-known/open-reading-source.json 發布探索文件，並實作 /v1/search、書籍詳情、章節目錄與章節內文介面。首版僅支援公開、無需登入的 HTTP(S) 書源。';
+      '服務在 /.well-known/open-reading-source.json 發布探索文件，並實作搜尋、書籍詳情、章節目錄與章節內文介面。v1.1 可選支援推薦、分類與瀏覽，仍僅面向公開、無需登入的 HTTP(S) 書源。';
 
   @override
   String get bookSourcesClose => '關閉';

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -8,7 +8,7 @@
   "@home": {
     "description": "首页标签"
   },
-  "library": "书库",
+  "library": "书架",
   "@library": {
     "description": "书库标签"
   },
@@ -16,6 +16,29 @@
   "@bookSources": {
     "description": "书源标签"
   },
+  "discover": "发现",
+  "discoverSubtitle": "从已启用的内容来源中搜索、浏览并发现下一本书",
+  "discoverRecommended": "推荐",
+  "discoverCategories": "分类",
+  "discoverLatest": "最新",
+  "discoverLoadFailed": "发现内容加载失败",
+  "discoverRetry": "重新加载",
+  "discoverUnsupportedTitle": "当前书源暂不支持此栏目",
+  "discoverUnsupportedMessage": "需要书源提供 {capability} 能力；现有书源仍可继续用于搜索。",
+  "@discoverUnsupportedMessage": {
+    "placeholders": {
+      "capability": {
+        "type": "String"
+      }
+    }
+  },
+  "discoverChooseCategory": "选择一个分类",
+  "discoverChooseCategoryHint": "选择上方分类后查看该书源提供的书籍。",
+  "discoverCategoryEmpty": "这个分类暂时没有可展示的书籍。",
+  "bookSourceManagementTitle": "书源管理",
+  "bookSourceManagementSubtitle": "管理内容来源的添加、启停与协议信息。发现页只保留找书体验。",
+  "settingsContentSourcesTitle": "内容来源",
+  "settingsContentSourcesSubtitle": "添加、启用或移除开放书源",
   "bookSourcesSubtitle": "连接开放书源，跨来源搜索可阅读内容",
   "bookSourcesAdd": "添加书源",
   "bookSourcesSearchHint": "输入书名或作者，搜索已启用书源",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -76,8 +76,8 @@
   "bookSourcesProtocolRepository": "协议开源仓库",
   "bookSourcesProtocolRepositoryOpen": "在 GitHub 查看",
   "bookSourcesProtocolRepositoryOpenFailed": "无法打开书源协议仓库",
-  "bookSourcesProtocolDialogTitle": "开放书源协议 v1",
-  "bookSourcesProtocolDialogBody": "服务在 /.well-known/open-reading-source.json 发布发现文档，并实现 /v1/search、书籍详情、章节目录与章节正文接口。首版仅支持公开、无需登录的 HTTP(S) 书源。",
+  "bookSourcesProtocolDialogTitle": "开放书源协议 v1.1",
+  "bookSourcesProtocolDialogBody": "服务在 /.well-known/open-reading-source.json 发布发现文档，并实现搜索、书籍详情、章节目录与章节正文接口。v1.1 可选支持推荐、分类与浏览，仍仅面向公开、无需登录的 HTTP(S) 书源。",
   "bookSourcesClose": "关闭",
   "bookSourcesIdentity": "书源 ID：{sourceId}\n书籍 ID：{bookId}",
   "@bookSourcesIdentity": {

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -2,8 +2,31 @@
   "@@locale": "zh_TW",
   "appTitle": "開元閱讀",
   "home": "首頁",
-  "library": "書庫",
+  "library": "書架",
   "bookSources": "書源",
+  "discover": "探索",
+  "discoverSubtitle": "從已啟用的內容來源搜尋、瀏覽並找到下一本書",
+  "discoverRecommended": "推薦",
+  "discoverCategories": "分類",
+  "discoverLatest": "最新",
+  "discoverLoadFailed": "探索內容載入失敗",
+  "discoverRetry": "重新載入",
+  "discoverUnsupportedTitle": "目前書源暫不支援此欄目",
+  "discoverUnsupportedMessage": "需要書源提供 {capability} 能力；現有書源仍可繼續用於搜尋。",
+  "@discoverUnsupportedMessage": {
+    "placeholders": {
+      "capability": {
+        "type": "String"
+      }
+    }
+  },
+  "discoverChooseCategory": "選擇一個分類",
+  "discoverChooseCategoryHint": "選擇上方分類後查看該書源提供的書籍。",
+  "discoverCategoryEmpty": "這個分類暫時沒有可顯示的書籍。",
+  "bookSourceManagementTitle": "書源管理",
+  "bookSourceManagementSubtitle": "管理內容來源的新增、啟停與協定資訊。探索頁只保留找書體驗。",
+  "settingsContentSourcesTitle": "內容來源",
+  "settingsContentSourcesSubtitle": "新增、啟用或移除開放書源",
   "bookSourcesSubtitle": "連接開放書源，跨來源搜尋可閱讀內容",
   "bookSourcesAdd": "新增書源",
   "bookSourcesSearchHint": "輸入書名或作者，搜尋已啟用書源",

--- a/lib/l10n/app_zh_TW.arb
+++ b/lib/l10n/app_zh_TW.arb
@@ -64,8 +64,8 @@
   "bookSourcesProtocolRepository": "協定開源倉庫",
   "bookSourcesProtocolRepositoryOpen": "在 GitHub 檢視",
   "bookSourcesProtocolRepositoryOpenFailed": "無法開啟書源協定倉庫",
-  "bookSourcesProtocolDialogTitle": "開放書源協定 v1",
-  "bookSourcesProtocolDialogBody": "服務在 /.well-known/open-reading-source.json 發布探索文件，並實作 /v1/search、書籍詳情、章節目錄與章節內文介面。首版僅支援公開、無需登入的 HTTP(S) 書源。",
+  "bookSourcesProtocolDialogTitle": "開放書源協定 v1.1",
+  "bookSourcesProtocolDialogBody": "服務在 /.well-known/open-reading-source.json 發布探索文件，並實作搜尋、書籍詳情、章節目錄與章節內文介面。v1.1 可選支援推薦、分類與瀏覽，仍僅面向公開、無需登入的 HTTP(S) 書源。",
   "bookSourcesClose": "關閉",
   "bookSourcesIdentity": "書源 ID：{sourceId}\n書籍 ID：{bookId}",
   "@bookSourcesIdentity": {

--- a/lib/pages/book_source_management_page.dart
+++ b/lib/pages/book_source_management_page.dart
@@ -1,0 +1,525 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../book_sources/models/registered_book_source.dart';
+import '../book_sources/protocol/book_source_protocol.dart';
+import '../book_sources/services/book_source_client.dart';
+import '../book_sources/services/book_source_registry.dart';
+import '../utils/localization_extension.dart';
+import '../utils/page_style_helper.dart';
+
+/// Low-frequency configuration for online content providers.
+///
+/// Discovery remains user-facing; adding, enabling and removing providers lives
+/// here so technical configuration does not interrupt the book-browsing flow.
+class BookSourceManagementPage extends StatefulWidget {
+  const BookSourceManagementPage({super.key});
+
+  @override
+  State<BookSourceManagementPage> createState() =>
+      _BookSourceManagementPageState();
+}
+
+class _BookSourceManagementPageState extends State<BookSourceManagementPage> {
+  final BookSourceRegistry _registry = BookSourceRegistry();
+  final BookSourceClient _client = BookSourceClient();
+
+  List<RegisteredBookSource> _sources = const [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadSources());
+  }
+
+  Future<void> _loadSources() async {
+    final sources = await _registry.load();
+    if (!mounted) return;
+    setState(() {
+      _sources = sources;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(context.l10n.bookSourceManagementTitle),
+        actions: [
+          IconButton(
+            tooltip: context.l10n.bookSourcesAdd,
+            onPressed: _showAddSourceDialog,
+            icon: const Icon(Icons.add_link_rounded),
+          ),
+          const SizedBox(width: 4),
+        ],
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: PageStyleHelper.backgroundGradient(context),
+        ),
+        child: SafeArea(
+          top: false,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 36),
+            children: [
+              Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 920),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Text(
+                        context.l10n.bookSourceManagementSubtitle,
+                        style: TextStyle(
+                          color: scheme.onSurfaceVariant,
+                          height: 1.45,
+                        ),
+                      ),
+                      const SizedBox(height: 20),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              context.l10n.bookSourcesManageTitle,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .titleLarge
+                                  ?.copyWith(fontWeight: FontWeight.w800),
+                            ),
+                          ),
+                          FilledButton.icon(
+                            onPressed: _showAddSourceDialog,
+                            icon: const Icon(Icons.add_rounded),
+                            label: Text(context.l10n.bookSourcesAdd),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 12),
+                      if (_loading)
+                        const Padding(
+                          padding: EdgeInsets.all(36),
+                          child: Center(child: CircularProgressIndicator()),
+                        )
+                      else if (_sources.isEmpty)
+                        _buildNoSourcesCard()
+                      else
+                        ..._sources.map(_buildSourceCard),
+                      const SizedBox(height: 22),
+                      _buildProtocolCard(),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoSourcesCard() {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: _panelDecoration(radius: 20),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.travel_explore_rounded, color: scheme.primary),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  context.l10n.bookSourcesNoSourcesTitle,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 5),
+                Text(
+                  context.l10n.bookSourcesNoSourcesDescription,
+                  style: TextStyle(
+                    color: scheme.onSurfaceVariant,
+                    height: 1.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSourceCard(RegisteredBookSource source) {
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
+        decoration: _panelDecoration(radius: 18),
+        child: Row(
+          children: [
+            _buildSourceIcon(source),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    source.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(height: 3),
+                  Text(
+                    source.description.isEmpty
+                        ? source.apiBaseUrl.host
+                        : source.description,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: scheme.onSurfaceVariant,
+                      fontSize: 12,
+                      height: 1.3,
+                    ),
+                  ),
+                  const SizedBox(height: 6),
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    children: source.capabilities
+                        .map(
+                          (capability) => Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 7,
+                              vertical: 3,
+                            ),
+                            decoration: BoxDecoration(
+                              color: scheme.secondaryContainer,
+                              borderRadius: BorderRadius.circular(999),
+                            ),
+                            child: Text(
+                              capability,
+                              style: TextStyle(
+                                color: scheme.onSecondaryContainer,
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        )
+                        .toList(growable: false),
+                  ),
+                ],
+              ),
+            ),
+            Switch.adaptive(
+              value: source.enabled,
+              onChanged: (enabled) => _setSourceEnabled(source, enabled),
+            ),
+            PopupMenuButton<String>(
+              tooltip: context.l10n.bookSourcesRemove,
+              onSelected: (value) {
+                if (value == 'remove') _confirmRemoveSource(source);
+              },
+              itemBuilder: (context) => [
+                PopupMenuItem(
+                  value: 'remove',
+                  child: Row(
+                    children: [
+                      const Icon(Icons.delete_outline_rounded),
+                      const SizedBox(width: 10),
+                      Text(context.l10n.bookSourcesRemove),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSourceIcon(RegisteredBookSource source) {
+    final scheme = Theme.of(context).colorScheme;
+    final fallback = Container(
+      width: 48,
+      height: 48,
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        source.name.characters.first.toUpperCase(),
+        style: TextStyle(
+          color: scheme.onSecondaryContainer,
+          fontWeight: FontWeight.w800,
+        ),
+      ),
+    );
+    if (source.iconUrl == null) return fallback;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: Image.network(
+        source.iconUrl.toString(),
+        width: 48,
+        height: 48,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => fallback,
+      ),
+    );
+  }
+
+  Widget _buildProtocolCard() {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(18),
+      decoration: _panelDecoration(radius: 20),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.api_rounded, color: scheme.primary),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  context.l10n.bookSourcesProtocolTitle,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  context.l10n.bookSourcesProtocolDescription,
+                  style: TextStyle(
+                    color: scheme.onSurfaceVariant,
+                    height: 1.45,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 4,
+                  children: [
+                    TextButton.icon(
+                      onPressed: _showProtocolDialog,
+                      icon: const Icon(Icons.schema_outlined, size: 18),
+                      label: Text(context.l10n.bookSourcesProtocolDetails),
+                    ),
+                    TextButton.icon(
+                      onPressed: _openProtocolRepository,
+                      icon: const Icon(Icons.open_in_new_rounded, size: 18),
+                      label: Text(context.l10n.bookSourcesProtocolRepository),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  BoxDecoration _panelDecoration({required double radius}) {
+    final palette = PageStyleHelper.palette(context);
+    return BoxDecoration(
+      color: palette.card,
+      borderRadius: BorderRadius.circular(radius),
+      border: Border.all(color: palette.border),
+    );
+  }
+
+  Future<void> _setSourceEnabled(
+    RegisteredBookSource source,
+    bool enabled,
+  ) async {
+    final sources = await _registry.setEnabled(source.id, enabled);
+    if (!mounted) return;
+    setState(() => _sources = sources);
+  }
+
+  Future<void> _confirmRemoveSource(RegisteredBookSource source) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(context.l10n.bookSourcesRemoveTitle),
+        content: Text(context.l10n.bookSourcesRemoveMessage),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(context.l10n.bookSourcesCancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(context.l10n.bookSourcesConfirm),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    final sources = await _registry.remove(source.id);
+    if (!mounted) return;
+    setState(() => _sources = sources);
+  }
+
+  Future<void> _showAddSourceDialog() async {
+    final controller = TextEditingController();
+    var connecting = false;
+    String? errorText;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: !connecting,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: Text(context.l10n.bookSourcesAddTitle),
+          content: SizedBox(
+            width: 440,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: controller,
+                  enabled: !connecting,
+                  autofocus: true,
+                  keyboardType: TextInputType.url,
+                  textInputAction: TextInputAction.done,
+                  decoration: InputDecoration(
+                    labelText: context.l10n.bookSourcesUrlLabel,
+                    hintText: context.l10n.bookSourcesUrlHint,
+                    errorText: errorText,
+                    prefixIcon: const Icon(Icons.link_rounded),
+                  ),
+                ),
+                if (connecting) ...[
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                      const SizedBox(width: 10),
+                      Text(context.l10n.bookSourcesConnecting),
+                    ],
+                  ),
+                ],
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: connecting ? null : () => Navigator.pop(dialogContext),
+              child: Text(context.l10n.bookSourcesCancel),
+            ),
+            FilledButton(
+              onPressed: connecting
+                  ? null
+                  : () async {
+                      setDialogState(() {
+                        connecting = true;
+                        errorText = null;
+                      });
+                      try {
+                        final discovered =
+                            await _client.discover(controller.text);
+                        final source = RegisteredBookSource.fromManifest(
+                          manifest: discovered.manifest,
+                          manifestUrl: discovered.manifestUrl,
+                        );
+                        final sources = await _registry.upsert(source);
+                        if (!mounted || !dialogContext.mounted) return;
+                        Navigator.pop(dialogContext);
+                        setState(() => _sources = sources);
+                        ScaffoldMessenger.of(this.context).showSnackBar(
+                          SnackBar(
+                            content: Text(
+                              '${this.context.l10n.bookSourcesAdded}: '
+                              '${source.name}',
+                            ),
+                          ),
+                        );
+                      } catch (error) {
+                        if (!dialogContext.mounted) return;
+                        setDialogState(() {
+                          connecting = false;
+                          errorText = error.toString();
+                        });
+                      }
+                    },
+              child: Text(context.l10n.bookSourcesConnect),
+            ),
+          ],
+        ),
+      ),
+    );
+    controller.dispose();
+  }
+
+  void _showProtocolDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(context.l10n.bookSourcesProtocolDialogTitle),
+        content: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                context.l10n.bookSourcesProtocolDialogBody,
+                style: const TextStyle(height: 1.5),
+              ),
+              const SizedBox(height: 18),
+              SelectableText(
+                openReadingSourceProtocolRepositoryUrl,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.primary,
+                  fontSize: 13,
+                  height: 1.4,
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton.icon(
+            onPressed: _openProtocolRepository,
+            icon: const Icon(Icons.open_in_new_rounded, size: 18),
+            label: Text(context.l10n.bookSourcesProtocolRepositoryOpen),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(context.l10n.bookSourcesClose),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _openProtocolRepository() async {
+    final opened = await launchUrl(
+      Uri.parse(openReadingSourceProtocolRepositoryUrl),
+      mode: LaunchMode.externalApplication,
+    );
+    if (!opened && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(context.l10n.bookSourcesProtocolRepositoryOpenFailed),
+        ),
+      );
+    }
+  }
+}

--- a/lib/pages/book_sources_page.dart
+++ b/lib/pages/book_sources_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../book_sources/models/registered_book_source.dart';
 import '../book_sources/protocol/book_source_protocol.dart';
@@ -11,6 +10,7 @@ import '../book_sources/services/book_source_shelf_service.dart';
 import '../utils/localization_extension.dart';
 import '../utils/page_style_helper.dart';
 import '../utils/ui_style.dart';
+import 'book_source_management_page.dart';
 import 'book_source_reader_page.dart';
 import 'home_layout_constants.dart';
 import 'home_shell_page.dart';
@@ -40,12 +40,21 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
   late final BookSourceShelfService _shelfService =
       BookSourceShelfService(client: _client);
   final TextEditingController _searchController = TextEditingController();
+  StreamSubscription<void>? _registrySubscription;
 
   List<RegisteredBookSource> _sources = const [];
   List<_SourcedBook> _results = const [];
+  List<_DiscoveryShelf> _discoveryShelves = const [];
+  List<_SourcedCategory> _categories = const [];
+  List<_SourcedBook> _browseResults = const [];
   String? _selectedSourceId;
+  _DiscoverSection _discoverSection = _DiscoverSection.recommended;
+  _SourcedCategory? _selectedCategory;
   bool _loadingSources = true;
   bool _searching = false;
+  bool _hasSearched = false;
+  bool _loadingDiscovery = false;
+  String? _discoveryError;
   int _failedSourceCount = 0;
 
   bool get _isMaterial3Style =>
@@ -55,11 +64,13 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
   @override
   void initState() {
     super.initState();
+    _registrySubscription = _registry.changes.listen((_) => _loadSources());
     unawaited(_loadSources());
   }
 
   @override
   void dispose() {
+    _registrySubscription?.cancel();
     _searchController.dispose();
     super.dispose();
   }
@@ -71,6 +82,7 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
       _sources = sources;
       _loadingSources = false;
     });
+    await _loadDiscoverySection();
   }
 
   Future<void> _search() async {
@@ -84,6 +96,7 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
     FocusScope.of(context).unfocus();
     setState(() {
       _searching = true;
+      _hasSearched = true;
       _failedSourceCount = 0;
     });
 
@@ -144,21 +157,21 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
                         const SizedBox(height: 14),
                         _buildSearchPanel(),
                         const SizedBox(height: 18),
-                        _buildSourceSection(),
-                        const SizedBox(height: 18),
-                        _buildProtocolCard(),
-                        const SizedBox(height: 22),
-                        _buildResultHeader(),
-                        if (_failedSourceCount > 0) ...[
-                          const SizedBox(height: 8),
-                          Text(
-                            context.l10n
-                                .bookSourcesFailedCount(_failedSourceCount),
-                            style: TextStyle(
-                              color: Theme.of(context).colorScheme.error,
-                              fontSize: 12,
+                        _buildDiscoveryTabs(),
+                        if (_hasSearched) ...[
+                          const SizedBox(height: 22),
+                          _buildResultHeader(),
+                          if (_failedSourceCount > 0) ...[
+                            const SizedBox(height: 8),
+                            Text(
+                              context.l10n
+                                  .bookSourcesFailedCount(_failedSourceCount),
+                              style: TextStyle(
+                                color: Theme.of(context).colorScheme.error,
+                                fontSize: 12,
+                              ),
                             ),
-                          ),
+                          ],
                         ],
                         const SizedBox(height: 10),
                       ],
@@ -172,6 +185,18 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
                 child: Padding(
                   padding: EdgeInsets.symmetric(vertical: 36),
                   child: Center(child: CircularProgressIndicator()),
+                ),
+              )
+            else if (!_hasSearched)
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: EdgeInsets.fromLTRB(16, 4, 16, bottomPadding),
+                  child: Center(
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 1048),
+                      child: _buildDiscoveryBody(),
+                    ),
+                  ),
                 ),
               )
             else if (_results.isEmpty)
@@ -213,7 +238,7 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
     return Padding(
       padding: const EdgeInsets.only(bottom: 18),
       child: Text(
-        context.l10n.bookSources,
+        context.l10n.discover,
         style: TextStyle(
           fontSize: 36,
           height: 1.05,
@@ -252,7 +277,7 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
                   const SizedBox(width: 12),
                   Expanded(
                     child: Text(
-                      context.l10n.bookSources,
+                      context.l10n.discover,
                       style:
                           Theme.of(context).textTheme.headlineSmall?.copyWith(
                                 fontWeight: FontWeight.w700,
@@ -263,7 +288,7 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
               ),
               const SizedBox(height: 10),
               Text(
-                context.l10n.bookSourcesSubtitle,
+                context.l10n.discoverSubtitle,
                 style: TextStyle(
                   color: scheme.onSurfaceVariant,
                   height: 1.45,
@@ -271,10 +296,10 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
               ),
             ],
           );
-          final button = FilledButton.icon(
-            onPressed: _showAddSourceDialog,
-            icon: const Icon(Icons.add_link_rounded),
-            label: Text(context.l10n.bookSourcesAdd),
+          final button = FilledButton.tonalIcon(
+            onPressed: _openSourceManagement,
+            icon: const Icon(Icons.tune_rounded),
+            label: Text(context.l10n.bookSourceManagementTitle),
           );
           if (compact) {
             return Column(
@@ -403,8 +428,10 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
                   _selectedSourceId =
                       value == _allSourcesMenuValue ? null : value;
                   _results = const [];
+                  _hasSearched = false;
                   _failedSourceCount = 0;
                 });
+                unawaited(_loadDiscoverySection());
               },
         items: [
           DropdownMenuItem(
@@ -500,211 +527,491 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
     );
   }
 
-  Widget _buildSourceSection() {
+  Widget _buildDiscoveryTabs() {
+    final scheme = Theme.of(context).colorScheme;
+    return SegmentedButton<_DiscoverSection>(
+      showSelectedIcon: false,
+      segments: [
+        ButtonSegment(
+          value: _DiscoverSection.recommended,
+          icon: const Icon(Icons.auto_awesome_outlined),
+          label: Text(context.l10n.discoverRecommended),
+        ),
+        ButtonSegment(
+          value: _DiscoverSection.categories,
+          icon: const Icon(Icons.category_outlined),
+          label: Text(context.l10n.discoverCategories),
+        ),
+        ButtonSegment(
+          value: _DiscoverSection.latest,
+          icon: const Icon(Icons.update_rounded),
+          label: Text(context.l10n.discoverLatest),
+        ),
+      ],
+      selected: {_discoverSection},
+      onSelectionChanged: (selection) {
+        if (selection.isEmpty) return;
+        setState(() {
+          _discoverSection = selection.first;
+          _hasSearched = false;
+        });
+        unawaited(_loadDiscoverySection());
+      },
+      style: ButtonStyle(
+        minimumSize: const WidgetStatePropertyAll(Size(44, 48)),
+        side: WidgetStatePropertyAll(
+          BorderSide(color: scheme.outlineVariant),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDiscoveryBody() {
+    if (_loadingSources || _loadingDiscovery) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 44),
+        child: Center(child: CircularProgressIndicator()),
+      );
+    }
+    if (_discoveryError != null) {
+      return _buildDiscoveryMessage(
+        icon: Icons.cloud_off_outlined,
+        title: context.l10n.discoverLoadFailed,
+        message: _discoveryError!,
+        actionLabel: context.l10n.discoverRetry,
+        onAction: _loadDiscoverySection,
+      );
+    }
+
+    return switch (_discoverSection) {
+      _DiscoverSection.recommended => _buildRecommendationContent(),
+      _DiscoverSection.categories => _buildCategoryContent(),
+      _DiscoverSection.latest => _buildLatestContent(),
+    };
+  }
+
+  Widget _buildRecommendationContent() {
+    if (_discoveryShelves.isEmpty) {
+      return _buildUnsupportedDiscoveryMessage('discover');
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: _discoveryShelves.map(_buildDiscoveryShelf).toList(),
+    );
+  }
+
+  Widget _buildDiscoveryShelf(_DiscoveryShelf shelf) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  shelf.title,
+                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                        fontWeight: FontWeight.w800,
+                      ),
+                ),
+              ),
+              _buildSourceBadge(shelf.source.name),
+            ],
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            height: 238,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: shelf.items.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 12),
+              itemBuilder: (context, index) {
+                final result = _SourcedBook(
+                  source: shelf.source,
+                  book: shelf.items[index],
+                );
+                return _buildDiscoveryBookCard(result);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryContent() {
+    if (_categories.isEmpty) {
+      return _buildUnsupportedDiscoveryMessage('categories');
+    }
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(
-          context.l10n.bookSourcesManageTitle,
-          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w700,
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: _categories.map((category) {
+            final selected = _selectedCategory == category;
+            return ChoiceChip(
+              selected: selected,
+              onSelected: (_) => _selectCategory(category),
+              avatar:
+                  selected ? const Icon(Icons.check_rounded, size: 16) : null,
+              label: Text(
+                _hasMultipleCategorySources
+                    ? '${category.name} · ${category.source.name}'
+                    : category.name,
               ),
+            );
+          }).toList(growable: false),
         ),
-        const SizedBox(height: 10),
-        if (_loadingSources)
-          const Center(
-            child: Padding(
-              padding: EdgeInsets.all(20),
-              child: CircularProgressIndicator(),
-            ),
+        const SizedBox(height: 18),
+        if (_selectedCategory == null)
+          _buildDiscoveryMessage(
+            icon: Icons.touch_app_outlined,
+            title: context.l10n.discoverChooseCategory,
+            message: context.l10n.discoverChooseCategoryHint,
           )
-        else if (_sources.isEmpty)
-          _buildNoSourcesCard()
+        else if (_browseResults.isEmpty)
+          _buildDiscoveryMessage(
+            icon: Icons.menu_book_outlined,
+            title: context.l10n.bookSourcesNoResults,
+            message: context.l10n.discoverCategoryEmpty,
+          )
         else
-          ..._sources.map(_buildSourceCard),
+          ..._browseResults.map(
+            (result) => Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: _buildBookResult(result),
+            ),
+          ),
       ],
     );
   }
 
-  Widget _buildNoSourcesCard() {
-    final scheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: _panelDecoration(radius: 20),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(Icons.travel_explore_rounded, color: scheme.primary),
-          const SizedBox(width: 14),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  context.l10n.bookSourcesNoSourcesTitle,
-                  style: const TextStyle(fontWeight: FontWeight.w700),
-                ),
-                const SizedBox(height: 5),
-                Text(
-                  context.l10n.bookSourcesNoSourcesDescription,
-                  style: TextStyle(
-                    color: scheme.onSurfaceVariant,
-                    height: 1.4,
-                  ),
-                ),
-              ],
+  Widget _buildLatestContent() {
+    if (_browseResults.isEmpty) {
+      return _buildUnsupportedDiscoveryMessage('browse');
+    }
+    return Column(
+      children: _browseResults
+          .map(
+            (result) => Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: _buildBookResult(result),
             ),
-          ),
-        ],
-      ),
+          )
+          .toList(growable: false),
     );
   }
 
-  Widget _buildSourceCard(RegisteredBookSource source) {
+  Widget _buildUnsupportedDiscoveryMessage(String capability) {
+    final hasEnabledSources = _sources.any((source) => source.enabled);
+    return _buildDiscoveryMessage(
+      icon: hasEnabledSources
+          ? Icons.extension_off_outlined
+          : Icons.travel_explore_outlined,
+      title: hasEnabledSources
+          ? context.l10n.discoverUnsupportedTitle
+          : context.l10n.bookSourcesNoSourcesTitle,
+      message: hasEnabledSources
+          ? context.l10n.discoverUnsupportedMessage(capability)
+          : context.l10n.bookSourcesNoSourcesDescription,
+      actionLabel: context.l10n.bookSourceManagementTitle,
+      onAction: _openSourceManagement,
+    );
+  }
+
+  Widget _buildDiscoveryMessage({
+    required IconData icon,
+    required String title,
+    required String message,
+    String? actionLabel,
+    FutureOr<void> Function()? onAction,
+  }) {
     final scheme = Theme.of(context).colorScheme;
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 10),
-      child: Container(
-        padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
-        decoration: _panelDecoration(radius: 18),
-        child: Row(
-          children: [
-            _buildSourceIcon(source),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    source.name,
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(fontWeight: FontWeight.w700),
-                  ),
-                  const SizedBox(height: 3),
-                  Text(
-                    source.description.isEmpty
-                        ? source.apiBaseUrl.host
-                        : source.description,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      color: scheme.onSurfaceVariant,
-                      fontSize: 12,
-                      height: 1.3,
-                    ),
-                  ),
-                ],
-              ),
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(24),
+      decoration: _panelDecoration(radius: 22),
+      child: Column(
+        children: [
+          Container(
+            width: 52,
+            height: 52,
+            decoration: BoxDecoration(
+              color: scheme.primaryContainer,
+              borderRadius: BorderRadius.circular(18),
             ),
-            Switch.adaptive(
-              value: source.enabled,
-              onChanged: (enabled) => _setSourceEnabled(source, enabled),
-            ),
-            PopupMenuButton<String>(
-              tooltip: '',
-              onSelected: (value) {
-                if (value == 'remove') _confirmRemoveSource(source);
-              },
-              itemBuilder: (context) => [
-                PopupMenuItem(
-                  value: 'remove',
-                  child: Row(
-                    children: [
-                      const Icon(Icons.delete_outline_rounded),
-                      const SizedBox(width: 10),
-                      Text(context.l10n.bookSourcesRemove),
-                    ],
-                  ),
+            child: Icon(icon, color: scheme.onPrimaryContainer),
+          ),
+          const SizedBox(height: 14),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w800,
                 ),
-              ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            message,
+            textAlign: TextAlign.center,
+            style: TextStyle(color: scheme.onSurfaceVariant, height: 1.45),
+          ),
+          if (actionLabel != null && onAction != null) ...[
+            const SizedBox(height: 16),
+            FilledButton.tonalIcon(
+              onPressed: () => onAction(),
+              icon: const Icon(Icons.tune_rounded),
+              label: Text(actionLabel),
             ),
           ],
-        ),
+        ],
       ),
     );
   }
 
-  Widget _buildSourceIcon(RegisteredBookSource source) {
+  Widget _buildDiscoveryBookCard(_SourcedBook result) {
     final scheme = Theme.of(context).colorScheme;
-    final fallback = Container(
-      width: 44,
-      height: 44,
-      decoration: BoxDecoration(
-        color: scheme.secondaryContainer,
-        borderRadius: BorderRadius.circular(13),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        source.name.characters.first.toUpperCase(),
-        style: TextStyle(
-          color: scheme.onSecondaryContainer,
-          fontWeight: FontWeight.w800,
-        ),
-      ),
-    );
-    if (source.iconUrl == null) return fallback;
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(13),
-      child: Image.network(
-        source.iconUrl.toString(),
-        width: 44,
-        height: 44,
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => fallback,
-      ),
-    );
-  }
-
-  Widget _buildProtocolCard() {
-    final scheme = Theme.of(context).colorScheme;
-    return Container(
-      padding: const EdgeInsets.all(18),
-      decoration: _panelDecoration(radius: 20),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Icon(Icons.api_rounded, color: scheme.primary),
-          const SizedBox(width: 14),
-          Expanded(
+    return SizedBox(
+      width: 132,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(18),
+          onTap: () => _showBookDetails(result),
+          child: Padding(
+            padding: const EdgeInsets.all(4),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  context.l10n.bookSourcesProtocolTitle,
-                  style: const TextStyle(fontWeight: FontWeight.w700),
-                ),
-                const SizedBox(height: 6),
-                Text(
-                  context.l10n.bookSourcesProtocolDescription,
-                  style: TextStyle(
-                    color: scheme.onSurfaceVariant,
-                    height: 1.45,
+                AspectRatio(
+                  aspectRatio: 2 / 3,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(14),
+                    child: result.book.coverUrl == null
+                        ? Container(
+                            color: scheme.secondaryContainer,
+                            child: Icon(
+                              Icons.menu_book_rounded,
+                              color: scheme.onSecondaryContainer,
+                            ),
+                          )
+                        : Image.network(
+                            result.book.coverUrl.toString(),
+                            fit: BoxFit.cover,
+                            errorBuilder: (_, __, ___) => Container(
+                              color: scheme.secondaryContainer,
+                              child: Icon(
+                                Icons.broken_image_outlined,
+                                color: scheme.onSecondaryContainer,
+                              ),
+                            ),
+                          ),
                   ),
                 ),
-                const SizedBox(height: 10),
-                Wrap(
-                  spacing: 8,
-                  runSpacing: 4,
-                  children: [
-                    TextButton.icon(
-                      onPressed: _showProtocolDialog,
-                      icon: const Icon(Icons.schema_outlined, size: 18),
-                      label: Text(context.l10n.bookSourcesProtocolDetails),
-                    ),
-                    TextButton.icon(
-                      onPressed: _openProtocolRepository,
-                      icon: const Icon(Icons.open_in_new_rounded, size: 18),
-                      label: Text(context.l10n.bookSourcesProtocolRepository),
-                    ),
-                  ],
+                const SizedBox(height: 8),
+                Text(
+                  result.book.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  result.book.author.isEmpty
+                      ? result.source.name
+                      : result.book.author,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: scheme.onSurfaceVariant,
+                    fontSize: 12,
+                  ),
                 ),
               ],
             ),
           ),
-        ],
+        ),
       ),
     );
+  }
+
+  Widget _buildSourceBadge(String label) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 5),
+      decoration: BoxDecoration(
+        color: scheme.secondaryContainer,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: scheme.onSecondaryContainer,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  bool get _hasMultipleCategorySources =>
+      _categories.map((category) => category.source.id).toSet().length > 1;
+
+  List<RegisteredBookSource> _discoveryTargets(String capability) {
+    return BookSourcesPage.searchTargets(_sources, _selectedSourceId)
+        .where((source) => source.capabilities.contains(capability))
+        .toList(growable: false);
+  }
+
+  Future<void> _loadDiscoverySection() async {
+    if (!mounted) return;
+    setState(() {
+      _loadingDiscovery = true;
+      _discoveryError = null;
+      _discoveryShelves = const [];
+      _categories = const [];
+      _browseResults = const [];
+      _selectedCategory = null;
+    });
+
+    try {
+      switch (_discoverSection) {
+        case _DiscoverSection.recommended:
+          await _loadRecommendations();
+        case _DiscoverSection.categories:
+          await _loadCategories();
+        case _DiscoverSection.latest:
+          await _loadLatest();
+      }
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _discoveryError = error.toString());
+    } finally {
+      if (mounted) setState(() => _loadingDiscovery = false);
+    }
+  }
+
+  Future<void> _loadRecommendations() async {
+    final targets = _discoveryTargets('discover');
+    final batches = await Future.wait(
+      targets.map((source) async {
+        try {
+          final page = await _client.getDiscovery(source);
+          return page.sections
+              .where((section) => section.items.isNotEmpty)
+              .map(
+                (section) => _DiscoveryShelf(
+                  source: source,
+                  title: section.title,
+                  items: section.items,
+                ),
+              )
+              .toList(growable: false);
+        } catch (_) {
+          return const <_DiscoveryShelf>[];
+        }
+      }),
+    );
+    if (!mounted) return;
+    setState(() {
+      _discoveryShelves = batches.expand((items) => items).toList();
+    });
+  }
+
+  Future<void> _loadCategories() async {
+    final targets = _discoveryTargets('categories');
+    final batches = await Future.wait(
+      targets.map((source) async {
+        try {
+          final categories = await _client.getCategories(source);
+          return categories
+              .map(
+                (category) => _SourcedCategory(
+                  source: source,
+                  id: category.id,
+                  name: category.name,
+                ),
+              )
+              .toList(growable: false);
+        } catch (_) {
+          return const <_SourcedCategory>[];
+        }
+      }),
+    );
+    if (!mounted) return;
+    setState(() => _categories = batches.expand((items) => items).toList());
+  }
+
+  Future<void> _loadLatest() async {
+    final targets = _discoveryTargets('browse');
+    final batches = await Future.wait(
+      targets.map((source) async {
+        try {
+          final page = await _client.browse(source, sort: 'latest');
+          return page.items
+              .map((book) => _SourcedBook(source: source, book: book))
+              .toList(growable: false);
+        } catch (_) {
+          return const <_SourcedBook>[];
+        }
+      }),
+    );
+    final results = batches.expand((items) => items).toList();
+    results.sort((a, b) {
+      final left = a.book.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final right = b.book.updatedAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return right.compareTo(left);
+    });
+    if (!mounted) return;
+    setState(() => _browseResults = results);
+  }
+
+  Future<void> _selectCategory(_SourcedCategory category) async {
+    if (!category.source.capabilities.contains('browse')) {
+      setState(() {
+        _selectedCategory = category;
+        _browseResults = const [];
+      });
+      return;
+    }
+    setState(() {
+      _selectedCategory = category;
+      _browseResults = const [];
+      _loadingDiscovery = true;
+      _discoveryError = null;
+    });
+    try {
+      final page = await _client.browse(
+        category.source,
+        category: category.id,
+        sort: 'popular',
+      );
+      if (!mounted) return;
+      setState(() {
+        _browseResults = page.items
+            .map(
+              (book) => _SourcedBook(source: category.source, book: book),
+            )
+            .toList(growable: false);
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => _discoveryError = error.toString());
+    } finally {
+      if (mounted) setState(() => _loadingDiscovery = false);
+    }
+  }
+
+  Future<void> _openSourceManagement() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const BookSourceManagementPage(),
+      ),
+    );
+    if (mounted) await _loadSources();
   }
 
   Widget _buildResultHeader() {
@@ -854,207 +1161,6 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
         width: 0.8,
       ),
     );
-  }
-
-  Future<void> _setSourceEnabled(
-    RegisteredBookSource source,
-    bool enabled,
-  ) async {
-    final sources = await _registry.setEnabled(source.id, enabled);
-    if (!mounted) return;
-    setState(() {
-      _sources = sources;
-      if (!enabled && _selectedSourceId == source.id) {
-        _selectedSourceId = null;
-      }
-      _results = const [];
-      _failedSourceCount = 0;
-    });
-  }
-
-  Future<void> _confirmRemoveSource(RegisteredBookSource source) async {
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.bookSourcesRemoveTitle),
-        content: Text(context.l10n.bookSourcesRemoveMessage),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: Text(context.l10n.bookSourcesCancel),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context, true),
-            child: Text(context.l10n.bookSourcesConfirm),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true) return;
-    final sources = await _registry.remove(source.id);
-    if (!mounted) return;
-    setState(() {
-      _sources = sources;
-      if (_selectedSourceId == source.id) _selectedSourceId = null;
-      _results = _results
-          .where((result) => result.source.id != source.id)
-          .toList(growable: false);
-    });
-  }
-
-  Future<void> _showAddSourceDialog() async {
-    final controller = TextEditingController();
-    var connecting = false;
-    String? errorText;
-    await showDialog<void>(
-      context: context,
-      barrierDismissible: !connecting,
-      builder: (dialogContext) => StatefulBuilder(
-        builder: (context, setDialogState) => AlertDialog(
-          title: Text(context.l10n.bookSourcesAddTitle),
-          content: SizedBox(
-            width: 440,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                TextField(
-                  controller: controller,
-                  enabled: !connecting,
-                  autofocus: true,
-                  keyboardType: TextInputType.url,
-                  textInputAction: TextInputAction.done,
-                  decoration: InputDecoration(
-                    labelText: context.l10n.bookSourcesUrlLabel,
-                    hintText: context.l10n.bookSourcesUrlHint,
-                    errorText: errorText,
-                    prefixIcon: const Icon(Icons.link_rounded),
-                  ),
-                ),
-                if (connecting) ...[
-                  const SizedBox(height: 16),
-                  Row(
-                    children: [
-                      const SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                      const SizedBox(width: 10),
-                      Text(context.l10n.bookSourcesConnecting),
-                    ],
-                  ),
-                ],
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: connecting ? null : () => Navigator.pop(dialogContext),
-              child: Text(context.l10n.bookSourcesCancel),
-            ),
-            FilledButton(
-              onPressed: connecting
-                  ? null
-                  : () async {
-                      setDialogState(() {
-                        connecting = true;
-                        errorText = null;
-                      });
-                      try {
-                        final discovered =
-                            await _client.discover(controller.text);
-                        final source = RegisteredBookSource.fromManifest(
-                          manifest: discovered.manifest,
-                          manifestUrl: discovered.manifestUrl,
-                        );
-                        final sources = await _registry.upsert(source);
-                        if (!mounted || !dialogContext.mounted) return;
-                        Navigator.pop(dialogContext);
-                        setState(() => _sources = sources);
-                        ScaffoldMessenger.of(this.context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              '${this.context.l10n.bookSourcesAdded}: '
-                              '${source.name}',
-                            ),
-                          ),
-                        );
-                      } catch (error) {
-                        if (!dialogContext.mounted) return;
-                        setDialogState(() {
-                          connecting = false;
-                          errorText = error.toString();
-                        });
-                      }
-                    },
-              child: Text(context.l10n.bookSourcesConnect),
-            ),
-          ],
-        ),
-      ),
-    );
-    controller.dispose();
-  }
-
-  void _showProtocolDialog() {
-    showDialog<void>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text(context.l10n.bookSourcesProtocolDialogTitle),
-        content: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                context.l10n.bookSourcesProtocolDialogBody,
-                style: const TextStyle(height: 1.5),
-              ),
-              const SizedBox(height: 18),
-              Text(
-                context.l10n.bookSourcesProtocolRepository,
-                style: const TextStyle(fontWeight: FontWeight.w700),
-              ),
-              const SizedBox(height: 6),
-              SelectableText(
-                openReadingSourceProtocolRepositoryUrl,
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.primary,
-                  fontSize: 13,
-                  height: 1.4,
-                ),
-              ),
-            ],
-          ),
-        ),
-        actions: [
-          TextButton.icon(
-            onPressed: _openProtocolRepository,
-            icon: const Icon(Icons.open_in_new_rounded, size: 18),
-            label: Text(context.l10n.bookSourcesProtocolRepositoryOpen),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(context.l10n.bookSourcesClose),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _openProtocolRepository() async {
-    final opened = await launchUrl(
-      Uri.parse(openReadingSourceProtocolRepositoryUrl),
-      mode: LaunchMode.externalApplication,
-    );
-    if (!opened && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(context.l10n.bookSourcesProtocolRepositoryOpenFailed),
-        ),
-      );
-    }
   }
 
   void _showBookDetails(_SourcedBook result) {
@@ -1286,6 +1392,8 @@ class _BookSourcesPageState extends State<BookSourcesPage> {
 
 enum _ShelfAddMode { online, local }
 
+enum _DiscoverSection { recommended, categories, latest }
+
 class _SourcedBook {
   final RegisteredBookSource source;
   final BookSourceBook book;
@@ -1298,6 +1406,30 @@ class _SearchBatch {
   final bool failed;
 
   const _SearchBatch({required this.items, this.failed = false});
+}
+
+class _DiscoveryShelf {
+  final RegisteredBookSource source;
+  final String title;
+  final List<BookSourceBook> items;
+
+  const _DiscoveryShelf({
+    required this.source,
+    required this.title,
+    required this.items,
+  });
+}
+
+class _SourcedCategory {
+  final RegisteredBookSource source;
+  final String id;
+  final String name;
+
+  const _SourcedCategory({
+    required this.source,
+    required this.id,
+    required this.name,
+  });
 }
 
 const String _allSourcesMenuValue = '__all_enabled_sources__';

--- a/lib/pages/home_shell_layout_part.dart
+++ b/lib/pages/home_shell_layout_part.dart
@@ -397,7 +397,11 @@ extension _HomeShellLayoutPart on _HomeShellPageState {
         onTap: _navigateToImport,
       );
     } else if (currentPage is BookSourcesPage) {
-      trailing = null;
+      trailing = _buildTopBarActionButton(
+        icon: Icons.tune_rounded,
+        tooltip: context.l10n.bookSourceManagementTitle,
+        onTap: _navigateToBookSourceManagement,
+      );
     } else if (currentPage is SettingsPage) {
       trailing = null;
     } else {
@@ -414,6 +418,14 @@ extension _HomeShellLayoutPart on _HomeShellPageState {
           title: title,
           trailing: trailing,
         ),
+      ),
+    );
+  }
+
+  Future<void> _navigateToBookSourceManagement() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const BookSourceManagementPage(),
       ),
     );
   }

--- a/lib/pages/home_shell_page.dart
+++ b/lib/pages/home_shell_page.dart
@@ -14,6 +14,7 @@ import 'home_widgets/home_page_wrappers.dart';
 import 'home_widgets/home_mobile_top_bar_widget.dart';
 import 'library_page.dart';
 import 'book_sources_page.dart';
+import 'book_source_management_page.dart';
 import 'settings_page.dart';
 import 'import_book_page.dart';
 import '../utils/layout_helper.dart';
@@ -134,9 +135,9 @@ class _HomeShellPageState extends State<HomeShellPage> {
         page: const LibraryPage(),
       ),
       HomeNavigationItem(
-        icon: Icons.hub_outlined,
-        selectedIcon: Icons.hub_rounded,
-        label: l10n.bookSources,
+        icon: Icons.explore_outlined,
+        selectedIcon: Icons.explore_rounded,
+        label: l10n.discover,
         page: const BookSourcesPage(),
       ),
       HomeNavigationItem(

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -20,6 +20,7 @@ import '../widgets/contributors_view.dart';
 import '../widgets/update_check_gate.dart';
 import 'home_shell_page.dart';
 import 'home_layout_constants.dart';
+import 'book_source_management_page.dart';
 import '../utils/localization_extension.dart';
 import '../utils/page_style_helper.dart';
 import '../utils/system_ui_helper.dart';
@@ -820,6 +821,19 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
           const SizedBox(height: 20),
           _buildSectionCard(
+            title: l10n.settingsContentSourcesTitle,
+            icon: Icons.hub_outlined,
+            children: [
+              _buildActionSetting(
+                title: l10n.bookSourceManagementTitle,
+                subtitle: l10n.settingsContentSourcesSubtitle,
+                onTap: _openBookSourceManagement,
+                icon: Icons.travel_explore_outlined,
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          _buildSectionCard(
             title: l10n.settingsAiAssistantTitle,
             icon: Icons.auto_awesome_outlined,
             children: [
@@ -907,6 +921,14 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  void _openBookSourceManagement() {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) => const BookSourceManagementPage(),
       ),
     );
   }

--- a/test/book_source_e2e_test.dart
+++ b/test/book_source_e2e_test.dart
@@ -20,7 +20,30 @@ void main() {
     );
 
     expect(source.id, 'dev.open-reading.example-source');
-    expect(source.capabilities, containsAll(['search', 'catalog', 'content']));
+    expect(
+      source.capabilities,
+      containsAll([
+        'search',
+        'discover',
+        'categories',
+        'browse',
+        'catalog',
+        'content',
+      ]),
+    );
+
+    final discovery = await client.getDiscovery(source);
+    expect(discovery.sections, isNotEmpty);
+    expect(discovery.sections.first.items, isNotEmpty);
+
+    final categories = await client.getCategories(source);
+    expect(categories, isNotEmpty);
+
+    final browsePage = await client.browse(
+      source,
+      category: categories.first.id,
+    );
+    expect(browsePage.items, isNotEmpty);
 
     final searchPage = await client.search(source, '协议');
     expect(searchPage.total, 1);

--- a/test/book_source_protocol_test.dart
+++ b/test/book_source_protocol_test.dart
@@ -59,6 +59,28 @@ void main() {
       expect(page.hasMore, isFalse);
     });
 
+    test('parses optional discovery and category responses', () {
+      final discovery = BookSourceDiscoveryPage.fromJson({
+        'sections': [
+          {
+            'id': 'featured',
+            'title': 'Featured',
+            'items': [
+              {'id': 'book-1', 'title': 'A Book'}
+            ],
+          },
+        ],
+      });
+      final category = BookSourceCategory.fromJson({
+        'id': 'fiction',
+        'name': 'Fiction',
+      });
+
+      expect(discovery.sections.single.id, 'featured');
+      expect(discovery.sections.single.items.single.title, 'A Book');
+      expect(category.name, 'Fiction');
+    });
+
     test('allows chapter content to omit its duplicated title', () {
       final content = BookSourceChapterContent.fromJson({
         'bookId': 'book-1',

--- a/test/book_source_search_layout_test.dart
+++ b/test/book_source_search_layout_test.dart
@@ -39,7 +39,7 @@ void main() {
         greaterThan(tester.getBottomLeft(scope).dy));
   });
 
-  testWidgets('opens the add-source dialog without dependency errors',
+  testWidgets('opens source management and the add-source dialog',
       (tester) async {
     tester.view.devicePixelRatio = 1;
     tester.view.physicalSize = const Size(390, 1000);
@@ -54,7 +54,12 @@ void main() {
     );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.add_link_rounded));
+    await tester.tap(find.byIcon(Icons.tune_rounded).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Manage sources'), findsWidgets);
+
+    await tester.tap(find.byIcon(Icons.add_link_rounded).first);
     await tester.pumpAndSettle();
 
     expect(find.byType(AlertDialog), findsOneWidget);

--- a/tool/example_book_source_server.dart
+++ b/tool/example_book_source_server.dart
@@ -103,6 +103,27 @@ class ExampleBookSourceServer {
       _search(request);
       return;
     }
+    if (segments.length == 3 &&
+        segments[0] == 'api' &&
+        segments[1] == 'v1' &&
+        segments[2] == 'discover') {
+      _discover(request.response);
+      return;
+    }
+    if (segments.length == 3 &&
+        segments[0] == 'api' &&
+        segments[1] == 'v1' &&
+        segments[2] == 'categories') {
+      _categories(request.response);
+      return;
+    }
+    if (segments.length == 3 &&
+        segments[0] == 'api' &&
+        segments[1] == 'v1' &&
+        segments[2] == 'browse') {
+      _browse(request);
+      return;
+    }
     if (segments.length >= 4 &&
         segments[0] == 'api' &&
         segments[1] == 'v1' &&
@@ -149,7 +170,15 @@ class ExampleBookSourceServer {
       'apiBaseUrl': publicBaseUri.resolve('api/').toString(),
       'websiteUrl': publicBaseUri.toString(),
       'languages': ['zh-CN', 'en'],
-      'capabilities': ['search', 'detail', 'catalog', 'content'],
+      'capabilities': [
+        'search',
+        'discover',
+        'categories',
+        'browse',
+        'detail',
+        'catalog',
+        'content',
+      ],
     };
   }
 
@@ -174,6 +203,71 @@ class ExampleBookSourceServer {
             .map((entry) => entry.book)
             .toList(growable: false);
 
+    _json(request.response, HttpStatus.ok, {
+      'items': items,
+      'page': page,
+      'pageSize': pageSize,
+      'total': matched.length,
+      'hasMore': start + items.length < matched.length,
+    });
+  }
+
+  void _discover(HttpResponse response) {
+    final books = _books.values.map((entry) => entry.book).toList();
+    _json(response, HttpStatus.ok, {
+      'sections': [
+        {
+          'id': 'featured',
+          'title': '编辑精选',
+          'items': books,
+        },
+        {
+          'id': 'recent',
+          'title': '最近更新',
+          'items': books.reversed.toList(growable: false),
+        },
+      ],
+    });
+  }
+
+  void _categories(HttpResponse response) {
+    final categories = <String>{};
+    for (final entry in _books.values) {
+      final values = entry.book['categories'];
+      if (values is List) categories.addAll(values.whereType<String>());
+    }
+    _json(response, HttpStatus.ok, {
+      'items': categories
+          .map((category) => {'id': category, 'name': category})
+          .toList(growable: false),
+    });
+  }
+
+  void _browse(HttpRequest request) {
+    final category = request.uri.queryParameters['category']?.trim();
+    final sort = request.uri.queryParameters['sort'] ?? 'latest';
+    final page = _positiveInt(request.uri.queryParameters['page'], fallback: 1);
+    final pageSize = _positiveInt(
+      request.uri.queryParameters['pageSize'],
+      fallback: 20,
+    ).clamp(1, 100);
+    final matched = _books.values
+        .where((entry) {
+          if (category == null || category.isEmpty) return true;
+          final values = entry.book['categories'];
+          return values is List && values.contains(category);
+        })
+        .map((entry) => entry.book)
+        .toList();
+    if (sort == 'latest') {
+      matched.sort(
+        (a, b) => '${b['updatedAt']}'.compareTo('${a['updatedAt']}'),
+      );
+    }
+    final start = (page - 1) * pageSize;
+    final items = start >= matched.length
+        ? const <Map<String, Object>>[]
+        : matched.skip(start).take(pageSize).toList(growable: false);
     _json(request.response, HttpStatus.ok, {
       'items': items,
       'page': page,

--- a/tool/example_book_source_server.dart
+++ b/tool/example_book_source_server.dart
@@ -163,7 +163,7 @@ class ExampleBookSourceServer {
     );
     return {
       'protocol': 'open-reading-source',
-      'protocolVersion': '1.0',
+      'protocolVersion': '1.1',
       'id': sourceId,
       'name': sourceName,
       'description': '仓库内置的本地协议测试书源，仅包含原创示例文本。',


### PR DESCRIPTION
## Summary

- replace the technical Sources tab with a user-facing Discover experience
- add capability-gated Recommended, Categories, and Latest sections
- retain cross-source search for existing ORSP 1.0 sources
- move source add/enable/remove/protocol actions into a dedicated management page
- expose content-source management from Discover and Settings
- align the client, example source, and bundled docs with ORSP 1.1

## Protocol

Companion protocol candidate: https://github.com/miloquinn/open-reading-source-protocol/pull/2

Existing ORSP 1.0 sources remain searchable. Discovery UI appears only for sources advertising `discover`, `categories`, or `browse`.

## Validation

- `flutter analyze`
- full `flutter test` suite (59 tests)
- signed Android release build and installation on PKT110