### PR TITLE
Fix release publishing for existing tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -217,10 +217,8 @@ jobs:
           notes_file="${RUNNER_TEMP}/release-notes.md"
           generated_notes_file="${RUNNER_TEMP}/generated-notes.md"
           custom_notes_file=".github/release-notes/${RELEASE_TAG}.md"
-          target_commitish="$(gh api "repos/${GH_REPO}" --jq '.default_branch')"
           gh api --method POST "repos/${GH_REPO}/releases/generate-notes" \
             -f tag_name="$RELEASE_TAG" \
-            -f target_commitish="$target_commitish" \
             --jq '.body' > "$generated_notes_file"
 
           : > "$notes_file"
@@ -251,7 +249,6 @@ jobs:
               --latest
           else
             gh release create "$RELEASE_TAG" release-assets/* \
-              --target "$RELEASE_TAG" \
               --title "开元阅读 ${RELEASE_TAG}" \
               --notes-file "$notes_file" \
               --latest


### PR DESCRIPTION
Removes invalid target_commitish arguments when generating notes and creating a GitHub Release for a tag that already exists. This fixes the publish-stage failure observed for v1.0.1; all platform artifacts built successfully and the release was completed manually.