### PR TITLE
Preserve book source text for invalid layout sizes

### DIFF
--- a/lib/book_sources/services/book_source_text_paginator.dart
+++ b/lib/book_sources/services/book_source_text_paginator.dart
@@ -61,6 +61,16 @@ List<BookSourceTextPage> paginateBookSourceText(
       ),
     ];
   }
+  if (width <= 0 || firstPageHeight <= 0 || pageHeight <= 0) {
+    return [
+      BookSourceTextPage(
+        text: text,
+        showsChapterTitle: true,
+        startOffset: 0,
+        endOffset: text.length,
+      ),
+    ];
+  }
 
   final flowStyle = NativeTextFlowStyle(
     textDirection: textDirection,

--- a/test/book_source_text_paginator_test.dart
+++ b/test/book_source_text_paginator_test.dart
@@ -65,6 +65,45 @@ void main() {
     expect(pages.length, greaterThan(1));
   });
 
+  testWidgets('preserves content when layout dimensions are not ready',
+      (tester) async {
+    const text = 'Chapter content should stay available.';
+
+    final pages = paginateBookSourceText(
+      text,
+      width: 0,
+      firstPageHeight: 360,
+      pageHeight: 480,
+      style: style,
+      textDirection: TextDirection.ltr,
+    );
+
+    expect(pages, hasLength(1));
+    expect(pages.single.text, text);
+    expect(pages.single.showsChapterTitle, isTrue);
+    expect(pages.single.startOffset, 0);
+    expect(pages.single.endOffset, text.length);
+  });
+
+  testWidgets('preserves long content when continuing page height is invalid',
+      (tester) async {
+    final text = List.filled(60, 'Long chapter content.').join('\n');
+
+    final pages = paginateBookSourceText(
+      text,
+      width: 180,
+      firstPageHeight: 120,
+      pageHeight: 0,
+      style: style,
+      textDirection: TextDirection.ltr,
+    );
+
+    expect(pages, hasLength(1));
+    expect(pages.single.text, text);
+    expect(pages.single.startOffset, 0);
+    expect(pages.single.endOffset, text.length);
+  });
+
   testWidgets('does not strand Chinese closing punctuation at a page start',
       (tester) async {
     const sentence =


### PR DESCRIPTION
## Summary

- Return the full chapter as a single page when book source pagination receives invalid layout dimensions.
- Add regression coverage for zero width and invalid continuing page height.

## Why

During early layout or transient resize states, the paginator can receive zero or invalid dimensions. The lower-level native paginator returns no ranges for invalid dimensions, which can drop remaining chapter text or cause `.first` to fail. Falling back to a complete single page preserves the user's content until valid measurements are available.

## Tests

- Not run locally: Flutter SDK is not installed in this environment (`flutter` command not found).